### PR TITLE
chunky chunks

### DIFF
--- a/crates/nvim-api/src/opts/set_extmark.rs
+++ b/crates/nvim-api/src/opts/set_extmark.rs
@@ -147,16 +147,21 @@ impl SetExtmarkOpts {
     }
 
     #[inline(always)]
-    pub fn set_virt_lines<Txt, Hl, Cnk>(&mut self, virt_lines: Cnk)
-    where
+    pub fn set_virt_lines<Txt, Hl, Cnk, ChunkyCnk>(
+        &mut self,
+        virt_lines: ChunkyCnk,
+    ) where
+        ChunkyCnk: IntoIterator<Item = Cnk>,
         Cnk: IntoIterator<Item = (Txt, Hl)>,
         Txt: Into<nvim::String>,
         Hl: Into<Object>,
     {
         self.0.virt_lines = virt_lines
             .into_iter()
-            .map(|(txt, hl)| {
-                Array::from_iter([Object::from(txt.into()), hl.into()])
+            .map(|chnky| {
+                Array::from_iter(chnky.into_iter().map(|(txt, hl)| {
+                    Array::from_iter([Object::from(txt.into()), hl.into()])
+                }))
             })
             .collect::<Array>()
             .into();
@@ -364,8 +369,12 @@ impl SetExtmarkOptsBuilder {
 
     /// Virtual lines to add next to the mark.
     #[inline(always)]
-    pub fn virt_lines<Txt, Hl, Cnk>(&mut self, virt_lines: Cnk) -> &mut Self
+    pub fn virt_lines<Txt, Hl, Cnk, ChunkyCnk>(
+        &mut self,
+        virt_lines: ChunkyCnk,
+    ) -> &mut Self
     where
+        ChunkyCnk: IntoIterator<Item = Cnk>,
         Cnk: IntoIterator<Item = (Txt, Hl)>,
         Txt: Into<nvim::String>,
         Hl: Into<Object>,

--- a/crates/nvim-api/src/types/extmark_infos.rs
+++ b/crates/nvim-api/src/types/extmark_infos.rs
@@ -38,7 +38,7 @@ pub struct ExtmarkInfos {
     pub ui_watched: Option<bool>,
 
     #[serde(default)]
-    pub virt_lines: Option<Vec<(String, String)>>,
+    pub virt_lines: Option<Vec<Vec<(String, String)>>>,
 
     #[serde(default)]
     pub virt_lines_above: Option<bool>,

--- a/tests/src/api/extmark.rs
+++ b/tests/src/api/extmark.rs
@@ -29,14 +29,7 @@ fn get_extmarks() {
         .end_row(0)
         .hl_group("Bar")
         .hl_mode(ExtmarkHlMode::Combine)
-        // TODO (same for virt_lines): both
-        // ```
-        // lua vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_text={"foo", "Foo"}})
-        // lua vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_text={"foo", {"Foo"}}})
-        // ```
-        // return an error w/ msg `Chunk is not an array`. Open issue upstream.
-        //
-        // .virt_lines([("foo", "Foo"), ("bar", "Bar")])
+        .virt_lines([[("foo", "Foo"), ("bar", "Bar")]])
         .virt_text([("foo", ["Foo", "Bar"])])
         .virt_text_pos(ExtmarkVirtTextPosition::Overlay)
         .build();
@@ -137,13 +130,7 @@ fn set_get_del_extmark() {
         .end_row(0)
         .hl_group("Bar")
         .hl_mode(ExtmarkHlMode::Combine)
-        // TODO (same for virt_lines): both
-        // ```
-        // lua vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_text={"foo", "Foo"}})
-        // lua vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_text={"foo", {"Foo"}}})
-        // ```
-        // return an error w/ msg `Chunk is not an array`. Open issue upstream.
-        // .virt_lines([("foo", "Foo"), ("bar", "Bar")])
+        .virt_lines([[("foo", "Foo"), ("bar", "Bar")]])
         .virt_text([("foo", vec!["Foo"]), ("bar", vec!["Bar", "Baz"])])
         .virt_text_pos(ExtmarkVirtTextPosition::Overlay)
         .build();


### PR DESCRIPTION
nvim_buf_set_extmarks & virt_lines require chunks of chunks (a.k.a. Chunky Chunks) to work.

(You can just delete this PR and do it differently if you want, but this solvees the problem you encountered with virt lines)