### PR TITLE
Allow getting the buffer handle and make `Buffer` copy

### DIFF
--- a/crates/nvim-api/src/buffer.rs
+++ b/crates/nvim-api/src/buffer.rs
@@ -88,6 +88,10 @@ impl Pushable for Buffer {
 }
 
 impl Buffer {
+    pub fn handle(&self) -> BufHandle {
+        self.0
+    }
+
     /// Shorthand for [`get_current_buf`](crate::get_current_buf).
     #[inline(always)]
     pub fn current() -> Self {

--- a/crates/nvim-api/src/buffer.rs
+++ b/crates/nvim-api/src/buffer.rs
@@ -27,7 +27,7 @@ use crate::LUA_INTERNAL_CALL;
 use crate::{Error, Result};
 
 /// A wrapper around a Neovim buffer handle.
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Buffer(pub(crate) BufHandle);
 
 impl fmt::Debug for Buffer {


### PR DESCRIPTION
Getting the internal handle is useful when `nxim_oxi` hasn't made bindings to something yet. I also don't see why `Buffer` shouldn't be `Copy`, as it's just an integer. I also don't see how the internals of `Buffer` could be changed to something `!Copy` in the future. I think the other types like `Window` should be made `Copy` too.