### PR TITLE
Prevent nvim_buf_get_name frees buf->b_ffname

### DIFF
--- a/crates/nvim-api/src/ffi/buffer.rs
+++ b/crates/nvim-api/src/ffi/buffer.rs
@@ -1,19 +1,10 @@
 use nvim_types::{
-    Array,
-    BufHandle,
-    Dictionary,
-    Error,
-    Integer,
-    LuaRef,
-    NonOwning,
-    Object,
-    String,
+    Array, BufHandle, Dictionary, Error, Integer, LuaRef, NonOwning, Object,
+    Str, String,
 };
 
 use crate::opts::{
-    KeyDict_get_commands,
-    KeyDict_keymap,
-    KeyDict_user_command,
+    KeyDict_get_commands, KeyDict_keymap, KeyDict_user_command,
 };
 
 extern "C" {
@@ -118,8 +109,7 @@ extern "C" {
     ) -> Array;
 
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L1086
-    pub(crate) fn nvim_buf_get_name(buf: BufHandle, err: *mut Error)
-        -> String;
+    pub(crate) fn nvim_buf_get_name(buf: BufHandle, err: *mut Error) -> Str;
 
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L876
     pub(crate) fn nvim_buf_get_offset(

--- a/crates/nvim-types/src/lib.rs
+++ b/crates/nvim-types/src/lib.rs
@@ -11,8 +11,10 @@ mod non_owning;
 mod object;
 #[cfg(feature = "serde")]
 pub mod serde;
+mod str;
 mod string;
 
+pub use crate::str::Str;
 pub use array::{Array, ArrayIterator};
 pub use dictionary::{DictIterator, Dictionary, KeyValuePair};
 pub use error::Error;

--- a/crates/nvim-types/src/str.rs
+++ b/crates/nvim-types/src/str.rs
@@ -1,0 +1,28 @@
+use std::{
+    ffi::{c_char, OsStr},
+    os::unix::prelude::OsStrExt,
+    path::PathBuf,
+    slice,
+};
+
+#[repr(C)]
+pub struct Str {
+    pub(crate) data: *mut c_char,
+    pub(crate) size: usize,
+}
+
+impl Str {
+    fn as_bytes(&self) -> &[u8] {
+        if self.data.is_null() {
+            &[]
+        } else {
+            unsafe { slice::from_raw_parts(self.data as *const u8, self.size) }
+        }
+    }
+}
+
+impl From<Str> for PathBuf {
+    fn from(s: Str) -> Self {
+        OsStr::from_bytes(s.as_bytes()).to_owned().into()
+    }
+}


### PR DESCRIPTION
nvim_buf_get_name C API doesn't copy memory but return a String with pointer to buf->b_ffname
rust shouldn't free buf->b_ffname

ref: 
 https://github.com/neovim/neovim/blob/09dffb9db7d16496e55e86f78ab60241533d86f6/src/nvim/api/buffer.c#L1038
 https://github.com/neovim/neovim/blob/09dffb9db7d16496e55e86f78ab60241533d86f6/src/nvim/api/private/helpers.c#L403-L408

# Reproduce code
```rust
use nvim_oxi as oxi;
use oxi::{Dictionary, Function};

#[oxi::module]
fn buffer_name_double_free_sample() -> oxi::Result<Dictionary> {
    Ok(Dictionary::from_iter([(
        "test",
        Function::from_fn(|()| {
            let buffer = oxi::api::get_current_buf();
            let name = buffer.get_name().unwrap();
            oxi::Result::<String>::Ok(String::from(name.to_str().unwrap()))
        }),
    )]))
}
```