### PR TITLE
Make tests work for workspaces

### DIFF
--- a/crates/nvim-oxi/Cargo.toml
+++ b/crates/nvim-oxi/Cargo.toml
@@ -23,7 +23,7 @@ neovim-nightly = ["nvim-types/neovim-nightly", "nvim-api/neovim-nightly"]
 diagnostic = ["nvim-diagnostic"]
 libuv = ["libuv-bindings"]
 mlua = ["dep:mlua"]
-test = ["oxi-test"]
+test = ["oxi-test", "dep:miniserde"]
 
 [dependencies]
 libuv-bindings = { version = "0.2.0", path = "../libuv-bindings", optional = true }
@@ -36,6 +36,7 @@ oxi-test = { version = "0.2.0", path = "../oxi-test", optional = true }
 
 mlua = { version = "0.8", optional = true }
 thiserror = "1.0"
+miniserde = { version = "0.1", optional = true }
 
 [dev-dependencies]
 mlua = { version = "0.8", features = ["luajit", "module", "vendored"] }

--- a/crates/nvim-oxi/src/lib.rs
+++ b/crates/nvim-oxi/src/lib.rs
@@ -95,4 +95,35 @@ pub use oxi_module::oxi_module as module;
 #[cfg(feature = "test")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test")))]
 pub use oxi_test::oxi_test as test;
+#[cfg(feature = "test")]
+#[doc(hidden)]
+pub mod __test {
+    use std::path::{PathBuf, Path};
+
+    pub fn get_target_dir(manifest_dir: &Path) -> PathBuf {
+        use miniserde::json;
+
+        let output = ::std::process::Command::new(
+            ::std::env::var("CARGO")
+                .ok()
+                .unwrap_or_else(|| "cargo".to_string()),
+        )
+        .arg("metadata")
+        .arg("--format-version=1")
+        .arg("--no-deps")
+        .current_dir(manifest_dir)
+        .output()
+        .unwrap();
+
+        let object: json::Object = json::from_str(&String::from_utf8(output.stdout).unwrap()).unwrap();
+
+        let target_dir = match object.get("target_directory").unwrap() {
+            json::Value::String(s) => s,
+            _ => panic!("Must be string value"),
+        };
+        
+        target_dir.into()
+    }
+}
+
 pub use toplevel::*;

--- a/crates/oxi-test/src/lib.rs
+++ b/crates/oxi-test/src/lib.rs
@@ -58,10 +58,8 @@ pub fn oxi_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[cfg(target_os = "macos")]
             target_filename.push_str(".so");
 
-            let target_dir =
-                ::std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                    .join("target")
-                    .join("debug");
+            let manifest_dir = env!("CARGO_MANIFEST_DIR");
+            let target_dir = nvim_oxi::__test::get_target_dir(manifest_dir.as_ref()).join("debug");
 
             let library_filepath = target_dir.join(library_filename);
 


### PR DESCRIPTION
Fixes #82 

It uses a trick found in [insta](https://github.com/mitsuhiko/insta/blob/master/src/env.rs#L344), because there is no cargo environment variable to access the target directory.