### PR TITLE
Fix segfault on nightly for `nvim_buf_get_lines()` and `nvim_buf_get_text()`

### DIFF
--- a/crates/nvim-api/src/buffer.rs
+++ b/crates/nvim-api/src/buffer.rs
@@ -314,6 +314,9 @@ impl Buffer {
                 start,
                 end,
                 strict_indexing,
+                #[cfg(feature = "neovim-nightly")]
+                // The nvim_buf_get_lines() function returns no line if we use an actual lstate here
+                std::ptr::null_mut(),
                 &mut err,
             )
         };
@@ -407,6 +410,9 @@ impl Buffer {
                 end,
                 end_col.try_into()?,
                 opts.non_owning(),
+                #[cfg(feature = "neovim-nightly")]
+                // The nvim_buf_get_text() function returns no line if we use an actual lstate here
+                std::ptr::null_mut(),
                 &mut err,
             )
         };

--- a/crates/nvim-api/src/ffi/buffer.rs
+++ b/crates/nvim-api/src/ffi/buffer.rs
@@ -107,6 +107,8 @@ extern "C" {
         start: Integer,
         end: Integer,
         strict_indexing: bool,
+        #[cfg(feature = "neovim-nightly")]
+        lstate: *mut luajit_bindings::ffi::lua_State,
         err: *mut Error,
     ) -> Array;
 
@@ -144,6 +146,8 @@ extern "C" {
         end_row: Integer,
         end_col: Integer,
         opts: NonOwning<Dictionary>,
+        #[cfg(feature = "neovim-nightly")]
+        lstate: *mut luajit_bindings::ffi::lua_State,
         err: *mut Error,
     ) -> Array;
 


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/19877 introduced breaking changes for the `nvim_buf_get_lines()` and `nvim_buf_get_text()` functions, adding a `luaState` argument. This PR passes `NULL` for that argument, as it seems safe to do (it will simply allocate on its own if no lua state is present).

Fixes #92 