### PR TITLE
Adapt to breaking changes in nightly

### DIFF
--- a/crates/nvim-api/src/buffer.rs
+++ b/crates/nvim-api/src/buffer.rs
@@ -27,7 +27,7 @@ use crate::LUA_INTERNAL_CALL;
 use crate::{Error, Result};
 
 /// A wrapper around a Neovim buffer handle.
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Buffer(pub(crate) BufHandle);
 
 impl fmt::Debug for Buffer {

--- a/crates/nvim-api/src/buffer.rs
+++ b/crates/nvim-api/src/buffer.rs
@@ -277,6 +277,7 @@ impl Buffer {
         let mode = nvim::String::from(mode);
         let maps = unsafe {
             nvim_buf_get_keymap(
+                #[cfg(feature = "neovim-0-7")]
                 LUA_INTERNAL_CALL,
                 self.0,
                 mode.non_owning(),

--- a/crates/nvim-api/src/buffer.rs
+++ b/crates/nvim-api/src/buffer.rs
@@ -158,6 +158,8 @@ impl Buffer {
         let command = command.to_object();
         unsafe {
             nvim_buf_create_user_command(
+                #[cfg(feature = "neovim-nightly")]
+                LUA_INTERNAL_CALL,
                 self.0,
                 name.non_owning(),
                 command.non_owning(),

--- a/crates/nvim-api/src/extmark.rs
+++ b/crates/nvim-api/src/extmark.rs
@@ -260,12 +260,18 @@ pub fn set_decoration_provider(
     ns_id: u32,
     opts: &DecorationProviderOpts,
 ) -> Result<()> {
+    #[cfg(feature = "neovim-0-7")]
     let opts = Dictionary::from(opts);
+    #[cfg(not(feature = "neovim-0-7"))]
+    let opts = KeyDict_set_decoration_provider::from(opts);
     let mut err = nvim::Error::new();
     unsafe {
         nvim_set_decoration_provider(
             ns_id as Integer,
+            #[cfg(feature = "neovim-0-7")]
             opts.non_owning(),
+            #[cfg(not(feature = "neovim-0-7"))]
+            &opts,
             &mut err,
         )
     };

--- a/crates/nvim-api/src/ffi/buffer.rs
+++ b/crates/nvim-api/src/ffi/buffer.rs
@@ -35,8 +35,9 @@ extern "C" {
         err: *mut Error,
     ) -> Object;
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L1383
+    // https://github.com/neovim/neovim/blob/v0.8.3/src/nvim/api/command.c#L936
     pub(crate) fn nvim_buf_create_user_command(
+        #[cfg(feature = "neovim-nightly")] channel_id: u64,
         buf: BufHandle,
         name: NonOwning<String>,
         command: NonOwning<Object>,

--- a/crates/nvim-api/src/ffi/buffer.rs
+++ b/crates/nvim-api/src/ffi/buffer.rs
@@ -94,9 +94,9 @@ extern "C" {
         err: *mut Error,
     ) -> Dictionary;
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L940
+    // https://github.com/neovim/neovim/blob/v0.8.3/src/nvim/api/buffer.c#L952
     pub(crate) fn nvim_buf_get_keymap(
-        channel_id: u64,
+        #[cfg(feature = "neovim-0-7")] channel_id: u64,
         buf: BufHandle,
         mode: NonOwning<String>,
         err: *mut Error,

--- a/crates/nvim-api/src/ffi/buffer.rs
+++ b/crates/nvim-api/src/ffi/buffer.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "neovim-0-7"))]
+use nvim_types::Arena;
 use nvim_types::{
     Array,
     BufHandle,
@@ -120,8 +122,11 @@ extern "C" {
     ) -> Array;
 
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L1086
-    pub(crate) fn nvim_buf_get_name(buf: BufHandle, err: *mut Error)
-        -> String;
+    pub(crate) fn nvim_buf_get_name(
+        buf: BufHandle,
+        #[cfg(not(feature = "neovim-0-7"))] arena: *mut Arena,
+        err: *mut Error,
+    ) -> String;
 
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L876
     pub(crate) fn nvim_buf_get_offset(
@@ -134,6 +139,7 @@ extern "C" {
     pub(crate) fn nvim_buf_get_option(
         buf: BufHandle,
         name: NonOwning<String>,
+        #[cfg(feature = "neovim-nightly")] arena: *mut Arena,
         err: *mut Error,
     ) -> Object;
 

--- a/crates/nvim-api/src/ffi/extmark.rs
+++ b/crates/nvim-api/src/ffi/extmark.rs
@@ -9,6 +9,8 @@ use nvim_types::{
     String,
 };
 
+#[cfg(not(feature = "neovim-0-7"))]
+use crate::opts::KeyDict_set_decoration_provider;
 use crate::opts::KeyDict_set_extmark;
 
 extern "C" {
@@ -75,10 +77,12 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L63
     pub(crate) fn nvim_get_namespaces() -> Dictionary;
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L987
+    // https://github.com/neovim/neovim/blob/v0.8.3/src/nvim/api/extmark.c#L1000
     pub(crate) fn nvim_set_decoration_provider(
         ns_id: Integer,
-        opts: NonOwning<Dictionary>,
+        #[cfg(feature = "neovim-0-7")] opts: NonOwning<Dictionary>,
+        #[cfg(not(feature = "neovim-0-7"))]
+        opts: *const KeyDict_set_decoration_provider,
         err: *mut Error,
     );
 }

--- a/crates/nvim-api/src/ffi/global.rs
+++ b/crates/nvim-api/src/ffi/global.rs
@@ -151,9 +151,9 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/vim.c#L109
     pub(crate) fn nvim_get_hl_id_by_name(name: NonOwning<String>) -> Integer;
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/vim.c#L1525
+    // https://github.com/neovim/neovim/blob/v0.8.3/src/nvim/api/vim.c#L1425
     pub(crate) fn nvim_get_keymap(
-        channel_id: u64,
+        #[cfg(feature = "neovim-0-7")] channel_id: u64,
         mode: NonOwning<String>,
     ) -> Array;
 

--- a/crates/nvim-api/src/ffi/global.rs
+++ b/crates/nvim-api/src/ffi/global.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "neovim-0-7"))]
+use nvim_types::Arena;
 use nvim_types::{
     Array,
     BufHandle,
@@ -134,6 +136,7 @@ extern "C" {
     pub(crate) fn nvim_get_hl_by_id(
         hl_id: Integer,
         rgb: bool,
+        #[cfg(not(feature = "neovim-0-7"))] arena: *mut Arena,
         error: *mut Error,
     ) -> Dictionary;
 
@@ -141,6 +144,7 @@ extern "C" {
     pub(crate) fn nvim_get_hl_by_name(
         name: NonOwning<String>,
         rgb: bool,
+        #[cfg(not(feature = "neovim-0-7"))] arena: *mut Arena,
         error: *mut Error,
     ) -> Dictionary;
 
@@ -166,6 +170,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/vim.c#L682
     pub(crate) fn nvim_get_option(
         name: NonOwning<String>,
+        #[cfg(feature = "neovim-nightly")] arena: *mut Arena,
         err: *mut Error,
     ) -> Object;
 

--- a/crates/nvim-api/src/ffi/window.rs
+++ b/crates/nvim-api/src/ffi/window.rs
@@ -62,6 +62,7 @@ extern "C" {
     pub(crate) fn nvim_win_get_option(
         win: WinHandle,
         name: NonOwning<String>,
+        #[cfg(feature = "neovim-nightly")] arena: *mut nvim_types::Arena,
         err: *mut Error,
     ) -> Object;
 

--- a/crates/nvim-api/src/global.rs
+++ b/crates/nvim-api/src/global.rs
@@ -355,9 +355,14 @@ pub fn get_hl_id_by_name(name: &str) -> Result<u32> {
 /// Returns an iterator over the global mapping definitions.
 pub fn get_keymap(mode: Mode) -> impl SuperIterator<KeymapInfos> {
     let mode = nvim::String::from(mode);
-    unsafe { nvim_get_keymap(LUA_INTERNAL_CALL, mode.non_owning()) }
-        .into_iter()
-        .map(|obj| KeymapInfos::from_object(obj).unwrap())
+    let keymaps = unsafe {
+        nvim_get_keymap(
+            #[cfg(feature = "neovim-0-7")]
+            LUA_INTERNAL_CALL,
+            mode.non_owning(),
+        )
+    };
+    keymaps.into_iter().map(|obj| KeymapInfos::from_object(obj).unwrap())
 }
 
 /// Binding to [`nvim_get_mark`](https://neovim.io/doc/user/api.html#nvim_get_mark()).

--- a/crates/nvim-api/src/global.rs
+++ b/crates/nvim-api/src/global.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+#[cfg(not(feature = "neovim-0-7"))]
+use nvim_types::Arena;
 use nvim_types::{
     self as nvim,
     conversion::{FromObject, ToObject},
@@ -309,7 +311,15 @@ pub fn get_current_win() -> Window {
 /// Gets a highlight definition by id.
 pub fn get_hl_by_id(hl_id: u32, rgb: bool) -> Result<HighlightInfos> {
     let mut err = nvim::Error::new();
-    let hl = unsafe { nvim_get_hl_by_id(hl_id.into(), rgb, &mut err) };
+    let hl = unsafe {
+        nvim_get_hl_by_id(
+            hl_id.into(),
+            rgb,
+            #[cfg(not(feature = "neovim-0-7"))]
+            &mut Arena::empty(),
+            &mut err,
+        )
+    };
     choose!(err, Ok(HighlightInfos::from_object(hl.into())?))
 }
 
@@ -319,7 +329,15 @@ pub fn get_hl_by_id(hl_id: u32, rgb: bool) -> Result<HighlightInfos> {
 pub fn get_hl_by_name(name: &str, rgb: bool) -> Result<HighlightInfos> {
     let name = nvim::String::from(name);
     let mut err = nvim::Error::new();
-    let hl = unsafe { nvim_get_hl_by_name(name.non_owning(), rgb, &mut err) };
+    let hl = unsafe {
+        nvim_get_hl_by_name(
+            name.non_owning(),
+            rgb,
+            #[cfg(not(feature = "neovim-0-7"))]
+            &mut Arena::empty(),
+            &mut err,
+        )
+    };
     choose!(err, Ok(HighlightInfos::from_object(hl.into())?))
 }
 
@@ -385,7 +403,14 @@ where
 {
     let name = nvim::String::from(name);
     let mut err = nvim::Error::new();
-    let obj = unsafe { nvim_get_option(name.non_owning(), &mut err) };
+    let obj = unsafe {
+        nvim_get_option(
+            name.non_owning(),
+            #[cfg(feature = "neovim-nightly")]
+            &mut Arena::empty(),
+            &mut err,
+        )
+    };
     choose!(err, Ok(Opt::from_object(obj)?))
 }
 

--- a/crates/nvim-api/src/opts/create_command.rs
+++ b/crates/nvim-api/src/opts/create_command.rs
@@ -41,7 +41,7 @@ pub struct CreateCommandOpts {
     #[builder(setter(custom))]
     nargs: Object,
 
-    #[cfg(any(feature = "neovim-0-8", feature = "neovim-nightly"))]
+    #[cfg(not(feature = "neovim-0-7"))]
     #[cfg_attr(
         docsrs,
         doc(cfg(any(feature = "neovim-0-8", feature = "neovim-nightly")))
@@ -126,7 +126,7 @@ pub(crate) struct KeyDict_user_command<'a> {
     force: Object,
     nargs: NonOwning<'a, Object>,
     range: NonOwning<'a, Object>,
-    #[cfg(any(feature = "neovim-0-8", feature = "neovim-nightly"))]
+    #[cfg(not(feature = "neovim-0-7"))]
     preview: NonOwning<'a, Object>,
     complete: NonOwning<'a, Object>,
     register_: Object,
@@ -144,7 +144,7 @@ impl<'a> From<&'a CreateCommandOpts> for KeyDict_user_command<'a> {
             force: opts.force.into(),
             nargs: opts.nargs.non_owning(),
             range: opts.range.non_owning(),
-            #[cfg(any(feature = "neovim-0-8", feature = "neovim-nightly"))]
+            #[cfg(not(feature = "neovim-0-7"))]
             preview: opts.preview.non_owning(),
             complete: opts.complete.non_owning(),
             register_: opts.register.into(),

--- a/crates/nvim-api/src/opts/set_highlight.rs
+++ b/crates/nvim-api/src/opts/set_highlight.rs
@@ -64,6 +64,15 @@ pub struct SetHighlightOpts {
 
     #[builder(setter(strip_option))]
     underline: Option<bool>,
+
+    #[builder(setter(custom))]
+    altfont: Object,
+
+    #[builder(setter(strip_option))]
+    bg_indexed: Option<bool>,
+
+    #[builder(setter(strip_option))]
+    fg_indexed: Option<bool>,
 }
 
 impl SetHighlightOpts {
@@ -110,6 +119,11 @@ impl SetHighlightOptsBuilder {
         self
     }
 
+    pub fn altfont(&mut self, altfont: &str) -> &mut Self {
+        self.altfont = Some(nvim::String::from(altfont).into());
+        self
+    }
+
     pub fn build(&mut self) -> SetHighlightOpts {
         self.fallible_build().expect("never fails, all fields have defaults")
     }
@@ -146,6 +160,8 @@ pub(crate) struct KeyDict_highlight<'a> {
     ctermbg: NonOwning<'a, Object>,
     ctermfg: NonOwning<'a, Object>,
     default_: Object,
+    #[cfg(feature = "neovim-nightly")]
+    altfont: NonOwning<'a, Object>,
     reverse: Object,
     fallback: Object,
     standout: Object,
@@ -157,7 +173,11 @@ pub(crate) struct KeyDict_highlight<'a> {
     underdash: Object,
     underline: Object,
     background: NonOwning<'a, Object>,
+    #[cfg(feature = "neovim-nightly")]
+    bg_indexed: Object,
     foreground: NonOwning<'a, Object>,
+    #[cfg(feature = "neovim-nightly")]
+    fg_indexed: Object,
     #[cfg(any(feature = "neovim-0-8", feature = "neovim-nightly"))]
     global_link: Object,
     #[cfg(any(feature = "neovim-0-8", feature = "neovim-nightly"))]
@@ -190,6 +210,8 @@ impl<'a> From<&'a SetHighlightOpts> for KeyDict_highlight<'a> {
             ctermbg: opts.ctermbg.non_owning(),
             ctermfg: opts.ctermfg.non_owning(),
             default_: opts.default.into(),
+            #[cfg(feature = "neovim-nightly")]
+            altfont: opts.altfont.non_owning(),
             reverse: opts.reverse.into(),
             fallback: Object::nil(),
             standout: opts.standout.into(),
@@ -201,7 +223,11 @@ impl<'a> From<&'a SetHighlightOpts> for KeyDict_highlight<'a> {
             underdash: opts.underdashed.into(),
             underline: opts.underline.into(),
             background: opts.background.non_owning(),
+            #[cfg(feature = "neovim-nightly")]
+            bg_indexed: opts.bg_indexed.into(),
             foreground: opts.foreground.non_owning(),
+            #[cfg(feature = "neovim-nightly")]
+            fg_indexed: opts.fg_indexed.into(),
             #[cfg(any(feature = "neovim-0-8", feature = "neovim-nightly"))]
             global_link: Object::nil(),
             #[cfg(any(feature = "neovim-0-8", feature = "neovim-nightly"))]

--- a/crates/nvim-api/src/opts/set_highlight.rs
+++ b/crates/nvim-api/src/opts/set_highlight.rs
@@ -65,8 +65,8 @@ pub struct SetHighlightOpts {
     #[builder(setter(strip_option))]
     underline: Option<bool>,
 
-    #[builder(setter(custom))]
-    altfont: Object,
+    #[builder(setter(strip_option))]
+    altfont: Option<bool>,
 
     #[builder(setter(strip_option))]
     bg_indexed: Option<bool>,
@@ -119,11 +119,6 @@ impl SetHighlightOptsBuilder {
         self
     }
 
-    pub fn altfont(&mut self, altfont: &str) -> &mut Self {
-        self.altfont = Some(nvim::String::from(altfont).into());
-        self
-    }
-
     pub fn build(&mut self) -> SetHighlightOpts {
         self.fallible_build().expect("never fails, all fields have defaults")
     }
@@ -161,7 +156,7 @@ pub(crate) struct KeyDict_highlight<'a> {
     ctermfg: NonOwning<'a, Object>,
     default_: Object,
     #[cfg(feature = "neovim-nightly")]
-    altfont: NonOwning<'a, Object>,
+    altfont: Object,
     reverse: Object,
     fallback: Object,
     standout: Object,
@@ -211,7 +206,7 @@ impl<'a> From<&'a SetHighlightOpts> for KeyDict_highlight<'a> {
             ctermfg: opts.ctermfg.non_owning(),
             default_: opts.default.into(),
             #[cfg(feature = "neovim-nightly")]
-            altfont: opts.altfont.non_owning(),
+            altfont: opts.altfont.into(),
             reverse: opts.reverse.into(),
             fallback: Object::nil(),
             standout: opts.standout.into(),

--- a/crates/nvim-api/src/types/highlight_infos.rs
+++ b/crates/nvim-api/src/types/highlight_infos.rs
@@ -2,12 +2,13 @@ use nvim_types::{
     conversion::{self, FromObject},
     serde::Deserializer,
     Object,
+    String,
 };
 use serde::Deserialize;
 
 /// Attributes related to a highlight group.
 #[non_exhaustive]
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Default)]
 pub struct HighlightInfos {
     pub background: Option<u32>,
     pub bg_indexed: Option<bool>,
@@ -25,6 +26,7 @@ pub struct HighlightInfos {
     pub underdot: Option<bool>,
     pub underline: Option<bool>,
     pub underlineline: Option<bool>,
+    pub altfont: Option<String>,
 }
 
 impl FromObject for HighlightInfos {

--- a/crates/nvim-api/src/types/highlight_infos.rs
+++ b/crates/nvim-api/src/types/highlight_infos.rs
@@ -2,7 +2,6 @@ use nvim_types::{
     conversion::{self, FromObject},
     serde::Deserializer,
     Object,
-    String,
 };
 use serde::Deserialize;
 
@@ -26,7 +25,7 @@ pub struct HighlightInfos {
     pub underdot: Option<bool>,
     pub underline: Option<bool>,
     pub underlineline: Option<bool>,
-    pub altfont: Option<String>,
+    pub altfont: Option<bool>,
 }
 
 impl FromObject for HighlightInfos {

--- a/crates/nvim-api/src/types/mod.rs
+++ b/crates/nvim-api/src/types/mod.rs
@@ -43,6 +43,8 @@ mod window_border_char;
 mod window_config;
 mod window_relative_to;
 mod window_style;
+mod window_title;
+mod window_title_position;
 
 pub use autocmd_callback_args::*;
 pub use autocmd_infos::*;
@@ -87,3 +89,5 @@ pub use window_border_char::*;
 pub use window_config::*;
 pub use window_relative_to::*;
 pub use window_style::*;
+pub use window_title::*;
+pub use window_title_position::*;

--- a/crates/nvim-api/src/types/window_config.rs
+++ b/crates/nvim-api/src/types/window_config.rs
@@ -74,6 +74,16 @@ pub struct WindowConfig {
     /// with lower indices.
     #[builder(setter(strip_option))]
     pub zindex: Option<u32>,
+
+    /// TODO
+    #[cfg(feature = "neovim-nightly")]
+    #[builder(setter(strip_option))]
+    pub title: Option<super::WindowTitle>,
+
+    /// TODO
+    #[cfg(feature = "neovim-nightly")]
+    #[builder(setter(strip_option))]
+    pub title_pos: Option<super::WindowTitlePosition>,
 }
 
 impl WindowConfig {
@@ -106,7 +116,7 @@ impl FromObject for WindowConfig {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub(crate) struct KeyDict_float_config {
@@ -114,6 +124,8 @@ pub(crate) struct KeyDict_float_config {
     row: Object,
     win: Object,
     style: Object,
+    #[cfg(feature = "neovim-nightly")]
+    title: Object,
     width: Object,
     height: Object,
     zindex: Object,
@@ -124,6 +136,8 @@ pub(crate) struct KeyDict_float_config {
     relative: Object,
     focusable: Object,
     noautocmd: Object,
+    #[cfg(feature = "neovim-nightly")]
+    title_pos: Object,
 }
 
 impl From<&WindowConfig> for KeyDict_float_config {
@@ -145,6 +159,8 @@ impl From<&WindowConfig> for KeyDict_float_config {
             row: config.row.into(),
             win,
             style: config.style.into(),
+            #[cfg(feature = "neovim-nightly")]
+            title: config.title.as_ref().into(),
             width: config.width.into(),
             height: config.height.into(),
             zindex: config.zindex.into(),
@@ -155,6 +171,8 @@ impl From<&WindowConfig> for KeyDict_float_config {
             relative: config.relative.as_ref().into(),
             focusable: config.focusable.into(),
             noautocmd: config.noautocmd.into(),
+            #[cfg(feature = "neovim-nightly")]
+            title_pos: config.title_pos.as_ref().into(),
         }
     }
 }

--- a/crates/nvim-api/src/types/window_relative_to.rs
+++ b/crates/nvim-api/src/types/window_relative_to.rs
@@ -17,6 +17,9 @@ pub enum WindowRelativeTo {
 
     /// Positions the window relative to the current cursor position.
     Cursor,
+
+    /// Positions the window relative to the current mouse cursor position..
+    Mouse,
 }
 
 impl From<&WindowRelativeTo> for Object {
@@ -26,6 +29,7 @@ impl From<&WindowRelativeTo> for Object {
             Editor => "editor",
             Window(_) => "win",
             Cursor => "cursor",
+            Mouse => "mouse",
         })
     }
 }

--- a/crates/nvim-api/src/types/window_title.rs
+++ b/crates/nvim-api/src/types/window_title.rs
@@ -1,0 +1,54 @@
+use nvim_types::{Array, Object, String};
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
+pub enum WindowTitle {
+    SimpleString(String),
+    ListOfText(Vec<(String, TitleHighlight)>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
+pub enum TitleHighlight {
+    SimpleString(String),
+    ListOfString(Vec<String>),
+}
+
+impl From<&WindowTitle> for Object {
+    fn from(title: &WindowTitle) -> Self {
+        match title {
+            WindowTitle::SimpleString(value) => value.clone().into(),
+            WindowTitle::ListOfText(list) => list
+                .into_iter()
+                .map(|(txt, hl)| {
+                    Array::from_iter(
+                        [txt.clone().into(), hl.into()] as [Object; 2]
+                    )
+                })
+                .collect::<Array>()
+                .into(),
+        }
+    }
+}
+
+impl From<&TitleHighlight> for Object {
+    fn from(hl: &TitleHighlight) -> Self {
+        match hl {
+            TitleHighlight::SimpleString(s) => s.clone().into(),
+            TitleHighlight::ListOfString(list) => {
+                list.iter().cloned().collect::<Array>().into()
+            },
+        }
+    }
+}
+
+impl From<String> for TitleHighlight {
+    fn from(value: String) -> Self {
+        Self::SimpleString(value)
+    }
+}
+
+impl From<Vec<String>> for TitleHighlight {
+    fn from(value: Vec<String>) -> Self {
+        Self::ListOfString(value.into_iter().collect())
+    }
+}

--- a/crates/nvim-api/src/types/window_title_position.rs
+++ b/crates/nvim-api/src/types/window_title_position.rs
@@ -1,0 +1,19 @@
+use nvim_types::Object;
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
+pub enum WindowTitlePosition {
+    Left,
+    Center,
+    Right,
+}
+
+impl From<&WindowTitlePosition> for Object {
+    fn from(pos: &WindowTitlePosition) -> Self {
+        Self::from(match pos {
+            WindowTitlePosition::Left => "left",
+            WindowTitlePosition::Center => "center",
+            WindowTitlePosition::Right => "right",
+        })
+    }
+}

--- a/crates/nvim-api/src/window.rs
+++ b/crates/nvim-api/src/window.rs
@@ -174,7 +174,13 @@ impl Window {
         let mut err = nvim::Error::new();
         let name = nvim::String::from(name);
         let obj = unsafe {
-            nvim_win_get_option(self.0, name.non_owning(), &mut err)
+            nvim_win_get_option(
+                self.0,
+                name.non_owning(),
+                #[cfg(feature = "neovim-nightly")]
+                &mut nvim_types::Arena::empty(),
+                &mut err,
+            )
         };
         choose!(err, Ok(Opt::from_object(obj)?))
     }

--- a/crates/nvim-types/src/arena.rs
+++ b/crates/nvim-types/src/arena.rs
@@ -1,0 +1,13 @@
+// https://github.com/neovim/neovim/blob/v0.8.3/src/nvim/memory.h#L50
+#[repr(C)]
+pub struct Arena {
+    cur_blk: *mut std::ffi::c_char,
+    pos: usize,
+    size: usize,
+}
+
+impl Arena {
+    pub fn empty() -> Self {
+        Self { cur_blk: std::ptr::null_mut(), pos: 0, size: 0 }
+    }
+}

--- a/crates/nvim-types/src/lib.rs
+++ b/crates/nvim-types/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::missing_safety_doc)]
 use std::ffi::{c_double, c_int};
 
+#[cfg(not(feature = "0-7"))]
+mod arena;
 mod array;
 pub mod conversion;
 mod dictionary;
@@ -13,6 +15,8 @@ mod object;
 pub mod serde;
 mod string;
 
+#[cfg(not(feature = "0-7"))]
+pub use arena::Arena;
 pub use array::{Array, ArrayIterator};
 pub use dictionary::{DictIterator, Dictionary, KeyValuePair};
 pub use error::Error;


### PR DESCRIPTION
* A new parameter of type `Arena*` has been added to some nvim API functions, this caused a crash anytime one of those functions would yield an error (since the new parameter has been inserted before the `err` one)
* New fields in the structs for highlights options
* New fields in the structs for windows options