### PR TITLE
docs(examples): update version to 0.3 in crate setup section

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -60,7 +60,7 @@ The first step is to create a new library crate with `cargo new --lib
 crate-type = ["cdylib"]
 
 [dependencies]
-nvim-oxi = "0.1"
+nvim-oxi = "0.3"
 ```
 
 Next, in `lib.rs` we'll annotate the entry point of the plugin with the


### PR DESCRIPTION
The `examples/README.md` has version 0.1 in the example `Cargo.toml` in the crate setup section. Just a minor thing I came across when reading the docs.