### PR TITLE
Split `nvim_oxi::serde::Error` into separate types

### DIFF
--- a/crates/types/src/conversion.rs
+++ b/crates/types/src/conversion.rs
@@ -28,7 +28,11 @@ pub enum Error {
 
     #[cfg(feature = "serde")]
     #[error(transparent)]
-    Serde(#[from] crate::serde::Error),
+    Deserialize(#[from] crate::serde::DeserializeError),
+
+    #[cfg(feature = "serde")]
+    #[error(transparent)]
+    Serialize(#[from] crate::serde::SerializeError),
 }
 
 /// Trait implemented for types can be obtained from an [`Object`].

--- a/crates/types/src/serde/error.rs
+++ b/crates/types/src/serde/error.rs
@@ -1,33 +1,101 @@
-use std::fmt;
+use core::fmt;
+use std::error::Error as StdError;
 
 use serde::{de, ser};
-use thiserror::Error as ThisError;
 
-pub type Result<T> = std::result::Result<T, Error>;
-
-#[derive(Clone, Debug, Eq, PartialEq, ThisError)]
-pub enum Error {
-    #[error("{0}")]
-    Serialize(String),
-
-    #[error("{0}")]
-    Deserialize(String),
-
-    #[error(transparent)]
-    FromInt(#[from] std::num::TryFromIntError),
-
-    #[error(transparent)]
-    FromUtf8(#[from] std::string::FromUtf8Error),
+/// The [`Serializer`](ser::Serializer)'s error type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SerializeError {
+    pub msg: String,
 }
 
-impl ser::Error for Error {
-    fn custom<T: fmt::Display>(msg: T) -> Self {
-        Self::Serialize(msg.to_string())
+impl fmt::Display for SerializeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.msg)
     }
 }
 
-impl de::Error for Error {
+impl StdError for SerializeError {}
+
+impl ser::Error for SerializeError {
+    #[inline]
     fn custom<T: fmt::Display>(msg: T) -> Self {
-        Self::Deserialize(msg.to_string())
+        Self { msg: msg.to_string() }
+    }
+}
+
+/// The [`Deserializer`](de::Deserializer)'s error type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DeserializeError {
+    Custom { msg: String },
+
+    DuplicateField { field: &'static str },
+
+    MissingField { field: &'static str },
+
+    UnknownField { variant: String, expected: &'static [&'static str] },
+
+    UnknownVariant { field: String, expected: &'static [&'static str] },
+}
+
+impl fmt::Display for DeserializeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Custom { msg } => write!(f, "{}", msg),
+            Self::DuplicateField { field } => {
+                write!(f, "duplicate field '{}'", field)
+            },
+            Self::MissingField { field } => {
+                write!(f, "missing field '{}'", field)
+            },
+            Self::UnknownField { variant, expected } => {
+                write!(
+                    f,
+                    "unknown field '{}', expected one of: {}",
+                    variant,
+                    expected.join(", ")
+                )
+            },
+            Self::UnknownVariant { field, expected } => {
+                write!(
+                    f,
+                    "unknown variant '{}', expected one of: {}",
+                    field,
+                    expected.join(", ")
+                )
+            },
+        }
+    }
+}
+
+impl StdError for DeserializeError {}
+
+impl de::Error for DeserializeError {
+    #[inline]
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Self::Custom { msg: msg.to_string() }
+    }
+
+    #[inline]
+    fn unknown_field(field: &str, expected: &'static [&'static str]) -> Self {
+        Self::UnknownField { variant: field.to_string(), expected }
+    }
+
+    #[inline]
+    fn unknown_variant(
+        field: &str,
+        expected: &'static [&'static str],
+    ) -> Self {
+        Self::UnknownVariant { field: field.to_string(), expected }
+    }
+
+    #[inline]
+    fn missing_field(field: &'static str) -> Self {
+        Self::MissingField { field }
+    }
+
+    #[inline]
+    fn duplicate_field(field: &'static str) -> Self {
+        Self::DuplicateField { field }
     }
 }

--- a/crates/types/src/serde/mod.rs
+++ b/crates/types/src/serde/mod.rs
@@ -8,5 +8,5 @@ mod error;
 mod ser;
 
 pub use de::Deserializer;
-pub use error::{Error, Result};
+pub use error::{DeserializeError, SerializeError};
 pub use ser::Serializer;

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,10 @@ pub enum Error {
     ObjectConversion(#[from] types::conversion::Error),
 
     #[error(transparent)]
-    Serde(#[from] types::serde::Error),
+    Serialize(#[from] types::serde::SerializeError),
+
+    #[error(transparent)]
+    Deserialize(#[from] types::serde::DeserializeError),
 
     #[cfg(feature = "libuv")]
     #[error(transparent)]


### PR DESCRIPTION
Splits what used to be a single enum into 2 separate enums, `DeserializeError` and `SerializeError`. 

`DeserializeError` has variants corresponding to the various methods of the [serde::de::Error](https://docs.rs/serde/latest/serde/de/trait.Error.html#provided-methods) trait.