### PR TITLE
Fix linking issues on windows MSVC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         neovim: [v0.8.3, v0.9.5, nightly]
         include:
           - neovim: v0.8.3

--- a/crates/api/src/ffi/autocmd.rs
+++ b/crates/api/src/ffi/autocmd.rs
@@ -2,6 +2,10 @@ use types::*;
 
 use crate::opts::*;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/autocmd.c#L570
     pub(crate) fn nvim_clear_autocmds(

--- a/crates/api/src/ffi/buffer.rs
+++ b/crates/api/src/ffi/buffer.rs
@@ -12,6 +12,10 @@ use types::{
 
 use crate::opts::*;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/buffer.c#L152
     pub(crate) fn nvim_buf_attach(

--- a/crates/api/src/ffi/extmark.rs
+++ b/crates/api/src/ffi/extmark.rs
@@ -11,6 +11,10 @@ use types::{
 
 use crate::opts::*;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/extmark.c#L950
     pub(crate) fn nvim_buf_add_highlight(

--- a/crates/api/src/ffi/global.rs
+++ b/crates/api/src/ffi/global.rs
@@ -2,6 +2,10 @@ use types::*;
 
 use crate::opts::*;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/vim.c#L1037
     pub(crate) fn nvim_chan_send(

--- a/crates/api/src/ffi/helpers.rs
+++ b/crates/api/src/ffi/helpers.rs
@@ -1,3 +1,7 @@
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/4f788f78f8b2d59a76b1a54a40af0c478eb3f929/src/nvim/api/private/helpers.c#L841
     #[cfg(feature = "neovim-nightly")]

--- a/crates/api/src/ffi/tabpage.rs
+++ b/crates/api/src/ffi/tabpage.rs
@@ -9,6 +9,10 @@ use types::{
     WinHandle,
 };
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/tabpage.c#L86
     pub(crate) fn nvim_tabpage_del_var(

--- a/crates/api/src/ffi/vimscript.rs
+++ b/crates/api/src/ffi/vimscript.rs
@@ -2,6 +2,10 @@ use types::{Array, Boolean, Dictionary, Error, NonOwning, Object, String};
 
 use crate::opts::*;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/vimscript.c#L283
     pub(crate) fn nvim_call_dict_function(

--- a/crates/api/src/ffi/win_config.rs
+++ b/crates/api/src/ffi/win_config.rs
@@ -2,6 +2,10 @@ use types::{Boolean, BufHandle, Dictionary, Error, WinHandle};
 
 use crate::types::WindowOpts;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/win_config.c#L159
     pub(crate) fn nvim_open_win(

--- a/crates/api/src/ffi/window.rs
+++ b/crates/api/src/ffi/window.rs
@@ -1,5 +1,9 @@
 use types::*;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "nvim.exe", kind = "raw-dylib", modifiers = "+verbatim")
+)]
 extern "C" {
     // https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/window.c#L428
     pub(crate) fn nvim_win_call(

--- a/crates/luajit/src/ffi.rs
+++ b/crates/luajit/src/ffi.rs
@@ -51,6 +51,10 @@ pub type lua_Integer = isize;
 // https://www.lua.org/manual/5.1/manual.html#lua_Number
 pub type lua_Number = c_double;
 
+#[cfg_attr(
+    all(target_os = "windows", target_env = "msvc"),
+    link(name = "lua51", kind = "raw-dylib")
+)]
 extern "C" {
     // https://www.lua.org/manual/5.1/manual.html#lua_call
     pub fn lua_call(L: *mut lua_State, nargs: c_int, nresults: c_int);

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,6 +12,10 @@ neovim-0-8 = ["nvim-oxi/neovim-0-8"]
 neovim-0-9 = ["nvim-oxi/neovim-0-9"]
 neovim-nightly = ["nvim-oxi/neovim-nightly"]
 
-[dependencies]
+[target.'cfg(not(any(target_os = "windows", target_env = "msvc")))'.dependencies]
 all_asserts = "2.3"
 nvim-oxi = { path = "..", features = ["libuv", "test"] }
+
+[target.'cfg(any(target_os = "windows", target_env = "msvc"))'.dependencies]
+all_asserts = "2.3"
+nvim-oxi = { path = "..", features = ["test"] }

--- a/tests/src/api/buffer.rs
+++ b/tests/src/api/buffer.rs
@@ -223,7 +223,7 @@ fn buf_terminal_name() {
         api::exec("lua =vim.api.nvim_buf_get_name(0)", true).unwrap().unwrap();
 
     #[cfg(feature = "neovim-0-8")]
-    let term_name_lua = term_name_lua.trim_matches('"').to_owned();
+    let term_name_lua = term_name_lua.trim_matches('"').replace("\\\\", "\\").to_owned();
 
     assert_eq!(term_name_oxi.display().to_string(), term_name_lua);
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,2 +1,3 @@
 mod api;
+#[cfg(not(any(target_os = "windows", target_env = "msvc")))]
 mod libuv;


### PR DESCRIPTION
Fixes linking issues on MSVC targets by marking relevant `extern "C"` blocks with the [`raw-dylib`](https://rust-lang.github.io/rfcs/2627-raw-dylib-kind.html) link attribute. Also uses the [`+verbatim`](https://doc.rust-lang.org/reference/items/external-blocks.html#linking-modifiers-verbatim) link modifier for `nvim.exe` symbols to ensure that the *executable* is linked against (otherwise, the linker might try to link against `nvim.exe.dll`.

Also refactors the test suite to fix possible edge cases for testing on windows. The previous implementation used [`std::os::windows::fs::symlink_file`](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html) which can fail if the user does not have symlink permissions (see the [Limitations](https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html#limitations) section of the symlink function). Fixed by using [`package.loadlib`](https://www.lua.org/manual/5.1/manual.html#pdf-package.loadlib) instead of `require` and directly calling the entry point function. This has the indirect consequence of simplifying the test macro because the new approach works for all targets, requires no symlinking and does not depend on `rtp`/lua search paths.

Fixes #125. Supersedes #147, shout out to @AregevDev, the author of that PR, for their work.

---

**Caveat**: `libuv` symbols can't be linked against in this manner. I don't think there's any way around this, it appears that none of the `libuv` functions are exported. `luajit` can't find any of those symbols on windows via `ffi` either.

For this reason, the `libuv` tests are currently guarded by a feature. That's a temporary fix, I think it's up to you @noib3 to decide how the `libuv` tests should be handled for windows CI.