### PR TITLE
Fix range bounds

### DIFF
--- a/crates/api/src/buffer.rs
+++ b/crates/api/src/buffer.rs
@@ -1,5 +1,5 @@
+use core::ops::RangeBounds;
 use std::fmt;
-use std::ops::RangeBounds;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 
@@ -339,7 +339,7 @@ impl Buffer {
         R: RangeBounds<usize>,
     {
         let mut err = nvim::Error::new();
-        let (start, end) = utils::range_to_limits(line_range);
+        let (start, end) = utils::range_to_limits::<true, _>(line_range);
         let lines = unsafe {
             nvim_buf_get_lines(
                 LUA_INTERNAL_CALL,
@@ -452,7 +452,7 @@ impl Buffer {
         let mut err = nvim::Error::new();
         #[cfg(not(feature = "neovim-nightly"))]
         let opts = types::Dictionary::from(opts);
-        let (start, end) = utils::range_to_limits(line_range);
+        let (start, end) = utils::range_to_limits::<false, _>(line_range);
         let lines = unsafe {
             nvim_buf_get_text(
                 LUA_INTERNAL_CALL,
@@ -576,7 +576,7 @@ impl Buffer {
     {
         let rpl = replacement.into_iter().map(Into::into).collect::<Array>();
         let mut err = nvim::Error::new();
-        let (start, end) = utils::range_to_limits(line_range);
+        let (start, end) = utils::range_to_limits::<true, _>(line_range);
         unsafe {
             nvim_buf_set_lines(
                 LUA_INTERNAL_CALL,
@@ -685,7 +685,7 @@ impl Buffer {
         Line: Into<nvim::String>,
     {
         let mut err = nvim::Error::new();
-        let (start, end) = utils::range_to_limits(line_range);
+        let (start, end) = utils::range_to_limits::<false, _>(line_range);
         unsafe {
             nvim_buf_set_text(
                 LUA_INTERNAL_CALL,

--- a/crates/api/src/extmark.rs
+++ b/crates/api/src/extmark.rs
@@ -30,7 +30,7 @@ impl Buffer {
     {
         let hl_group = nvim::String::from(hl_group);
         let mut err = nvim::Error::new();
-        let (start, end) = utils::range_to_limits(byte_range);
+        let (start, end) = utils::range_to_limits::<true, _>(byte_range);
         let ns_id = unsafe {
             nvim_buf_add_highlight(
                 self.0,
@@ -62,7 +62,7 @@ impl Buffer {
         R: RangeBounds<usize>,
     {
         let mut err = nvim::Error::new();
-        let (start, end) = utils::range_to_limits(line_range);
+        let (start, end) = utils::range_to_limits::<true, _>(line_range);
         unsafe {
             nvim_buf_clear_namespace(
                 self.0,

--- a/crates/api/src/utils.rs
+++ b/crates/api/src/utils.rs
@@ -1,8 +1,11 @@
-use std::ops::{Bound, RangeBounds};
+use core::ops::{Bound, RangeBounds};
 
 use types::Integer;
 
-pub(crate) fn range_to_limits<R>(range: R) -> (Integer, Integer)
+#[inline]
+pub(crate) fn range_to_limits<const IS_END_EXCLUSIVE: bool, R>(
+    range: R,
+) -> (Integer, Integer)
 where
     R: RangeBounds<usize>,
 {
@@ -15,8 +18,12 @@ where
     let end = match range.end_bound() {
         // The Neovim API generally uses -1 to indicate "until the end".
         Bound::Unbounded => -1,
-        Bound::Excluded(&n) => n.saturating_sub(1) as Integer,
-        Bound::Included(&n) => n as Integer,
+        Bound::Excluded(&n) => {
+            (if IS_END_EXCLUSIVE { n } else { n.saturating_sub(1) }) as Integer
+        },
+        Bound::Included(&n) => {
+            (if IS_END_EXCLUSIVE { n + 1 } else { n }) as Integer
+        },
     };
 
     (start, end)

--- a/tests/src/api/buffer.rs
+++ b/tests/src/api/buffer.rs
@@ -1,9 +1,9 @@
 use all_asserts::*;
-use nvim_oxi as oxi;
+use nvim_oxi as nvim;
 use nvim_oxi::api::{self, opts::*, types::*, Buffer};
 
-#[oxi::test]
-fn attach() {
+#[nvim::test]
+fn buf_attach() {
     let buf = Buffer::current();
 
     let opts = BufAttachOpts::builder()
@@ -21,14 +21,14 @@ fn attach() {
     assert!(bytes_written.is_ok(), "{bytes_written:?}");
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_call() {
     let buf = Buffer::current();
     let res = buf.call(|_| Ok(()));
     assert_eq!(Ok(()), res);
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_create_del_user_command() {
     let mut buf = Buffer::current();
 
@@ -53,26 +53,26 @@ fn buf_create_del_user_command() {
     assert_eq!(Ok(()), buf.del_user_command("Bar"));
 }
 
-#[oxi::test]
-fn get_changedtick() {
+#[nvim::test]
+fn buf_get_changedtick() {
     let buf = Buffer::current();
     assert!(buf.get_changedtick().is_ok());
 }
 
-#[oxi::test]
-fn loaded_n_valid() {
+#[nvim::test]
+fn buf_loaded_n_valid() {
     let buf = Buffer::current();
     assert!(buf.is_loaded());
     assert!(buf.is_valid());
 }
 
-#[oxi::test]
-fn new_buf_delete() {
+#[nvim::test]
+fn buf_new_delete() {
     let buf = api::create_buf(true, false).unwrap();
     assert_eq!(Ok(()), buf.delete(&Default::default()));
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_set_get_del_keymap() {
     let mut buf = Buffer::current();
 
@@ -92,7 +92,7 @@ fn buf_set_get_del_keymap() {
     assert_eq!(Ok(()), res);
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_set_get_del_nvo_keymap() {
     let mut buf = Buffer::current();
 
@@ -114,8 +114,8 @@ fn buf_set_get_del_nvo_keymap() {
     assert_eq!(Ok(()), res);
 }
 
-#[oxi::test]
-fn set_get_del_lines() {
+#[nvim::test]
+fn buf_set_get_del_lines() {
     let mut buf = Buffer::current();
 
     assert_eq!(Ok(()), buf.set_lines(.., true, ["foo", "bar", "baz"]));
@@ -132,7 +132,7 @@ fn set_get_del_lines() {
     assert_eq!(Ok(1), buf.line_count());
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_set_get_del_mark() {
     let mut buf = Buffer::current();
     let opts = SetMarkOpts::default();
@@ -146,8 +146,8 @@ fn buf_set_get_del_mark() {
     assert_eq!(Ok(()), res);
 }
 
-#[oxi::test]
-fn set_get_del_text() {
+#[nvim::test]
+fn buf_set_get_del_text() {
     let mut buf = Buffer::current();
 
     assert_eq!(Ok(()), buf.set_text(.., 0, 0, ["foo", "bar", "baz"]));
@@ -178,7 +178,7 @@ fn set_get_del_text() {
     assert_eq!(Ok(1), buf.line_count());
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_set_get_del_var() {
     let mut buf = Buffer::current();
     buf.set_var("foo", 42).unwrap();
@@ -186,8 +186,8 @@ fn buf_set_get_del_var() {
     assert_eq!(Ok(()), buf.del_var("foo"));
 }
 
-#[oxi::test]
-fn set_get_name() {
+#[nvim::test]
+fn buf_set_get_name() {
     let mut buf = Buffer::current();
 
     assert_eq!("", buf.get_name().unwrap().display().to_string());
@@ -202,7 +202,7 @@ fn set_get_name() {
     assert_eq!(Ok(()), buf.set_name(""));
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_set_get_option() {
     let mut buf = Buffer::current();
 
@@ -213,7 +213,7 @@ fn buf_set_get_option() {
     assert!(!buf.get_option::<bool>("modified").unwrap());
 }
 
-#[oxi::test]
+#[nvim::test]
 fn buf_terminal_name() {
     api::command("term").unwrap();
 
@@ -223,7 +223,8 @@ fn buf_terminal_name() {
         api::exec("lua =vim.api.nvim_buf_get_name(0)", true).unwrap().unwrap();
 
     #[cfg(feature = "neovim-0-8")]
-    let term_name_lua = term_name_lua.trim_matches('"').replace("\\\\", "\\").to_owned();
+    let term_name_lua =
+        term_name_lua.trim_matches('"').replace("\\\\", "\\").to_owned();
 
     assert_eq!(term_name_oxi.display().to_string(), term_name_lua);
 }

--- a/tests/src/api/window.rs
+++ b/tests/src/api/window.rs
@@ -87,7 +87,7 @@ fn get_tabpage() {
 #[oxi::test]
 fn set_get_cursor() {
     let mut buf = Buffer::current();
-    buf.set_lines(0..=1, true, ["foo"]).unwrap();
+    buf.set_lines(.., true, ["foo"]).unwrap();
 
     let mut win = Window::current();
 
@@ -97,7 +97,7 @@ fn set_get_cursor() {
     assert_eq!(Ok(()), win.set_cursor(1, 42));
     assert_eq!(Ok((1, 2)), win.get_cursor());
 
-    buf.set_lines(0..=1, true, [""]).unwrap();
+    buf.set_lines(.., true, [""]).unwrap();
 
     assert_eq!(Ok((1, 0)), win.get_cursor());
 }


### PR DESCRIPTION
Fixes a few off-by-one errors caused by Neovim wanting either end-exclusive or end-inclusive indices depending on the function.