### PR TITLE
LuaApi neovim function bindings and expose buffer number

### DIFF
--- a/crates/api/src/buffer.rs
+++ b/crates/api/src/buffer.rs
@@ -276,6 +276,12 @@ impl Buffer {
         choose!(err, ())
     }
 
+
+    /// Returns the current buffer number.
+    pub fn bufnr(&self) -> i32 {
+        self.0
+    }
+
     /// Binding to [`nvim_buf_get_changedtick()`][1].
     ///
     /// [1]: https://neovim.io/doc/user/api.html#nvim_buf_get_changedtick()


### PR DESCRIPTION
- Adds Lua functions bindings to some useful calls, and I can expand in the future. The set_keymap is useful because it will allow for functions instead of strings 
-  Expose buffer number because some lua functions require buffer number to be passed.

I'm not so good with setting the features correctly, and maybe you prefer a different location for the LuaApi file. Not sure where it should come, maybe you can change that maybe yourself.

## Steps to test features
- Clone my plugin: https://github.com/Norlock/nvim-traveller-rs/tree/feat/mlua-utils
- Create some binding to open the navigation (see README.md).
- After open (empty buffer) press 'q' to quit.
