### PR TITLE
Drop `once_cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ api = { path = "./crates/api", package = "nvim-oxi-api" }
 libuv = { path = "./crates/libuv", package = "nvim-oxi-libuv" }
 luajit = { path = "./crates/luajit", package = "nvim-oxi-luajit" }
 macros = { path = "./crates/macros", package = "nvim-oxi-macros" }
-once_cell = "1.19"
 thiserror = "1.0"
 types = { path = "./crates/types", package = "nvim-oxi-types" }
 

--- a/crates/libuv/Cargo.toml
+++ b/crates/libuv/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 
 [dependencies]
 luajit = { workspace = true }
-once_cell = { workspace = true }
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/libuv/src/loop.rs
+++ b/crates/libuv/src/loop.rs
@@ -1,5 +1,6 @@
+use core::cell::OnceCell;
+
 use luajit::ffi::lua_State;
-use once_cell::unsync::OnceCell;
 
 use crate::ffi;
 

--- a/crates/luajit/Cargo.toml
+++ b/crates/luajit/Cargo.toml
@@ -8,7 +8,6 @@ documentation.workspace = true
 license.workspace = true
 
 [dependencies]
-once_cell = { workspace = true }
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/luajit/src/state.rs
+++ b/crates/luajit/src/state.rs
@@ -1,4 +1,4 @@
-use once_cell::unsync::OnceCell;
+use core::cell::OnceCell;
 
 use crate::ffi::lua_State;
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -13,7 +13,6 @@ serde = ["dep:serde"]
 [dependencies]
 libc = "0.2"
 luajit = { workspace = true }
-once_cell = { workspace = true }
 serde = { version = "1.0", optional = true }
 thiserror = { workspace = true }
 

--- a/crates/types/src/arena.rs
+++ b/crates/types/src/arena.rs
@@ -1,8 +1,8 @@
+use core::cell::OnceCell;
 use core::ffi::c_char;
 use core::ptr;
 
 use libc::size_t;
-use once_cell::unsync::OnceCell;
 
 thread_local! {
     static ARENA: OnceCell<Arena> = const { OnceCell::new() };


### PR DESCRIPTION
Drops the `once_cell` dependency by using `core::cell::OnceCell` instead.