### PR TITLE
Improve the output of the `test` macro.

### DIFF
--- a/crates/macros/src/test.rs
+++ b/crates/macros/src/test.rs
@@ -29,7 +29,26 @@ pub fn test(attrs: TokenStream, item: TokenStream) -> TokenStream {
     quote! {
         #[test]
         fn #test_name() -> ::core::result::Result<(), ::std::string::String> {
-            #nvim_oxi::tests::test_body(stringify!(#plugin_name), #extra_cmd)
+            let library_name = {
+                let mut s = ::std::string::String::new();
+                s.push_str(::std::env::consts::DLL_PREFIX);
+                s.push_str(env!("CARGO_CRATE_NAME"));
+                s.push_str(::std::env::consts::DLL_SUFFIX);
+                s
+            };
+
+            let manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+            // The full path to the compiled library.
+            let library_path = #nvim_oxi::tests::target_dir(manifest_dir.as_ref())
+                .join("debug")
+                .join(library_name);
+
+            #nvim_oxi::tests::test_body(
+                &library_path,
+                stringify!(#plugin_name),
+                #extra_cmd,
+            )
         }
 
         #[#nvim_oxi::plugin(nvim_oxi = #nvim_oxi)]

--- a/crates/macros/src/test.rs
+++ b/crates/macros/src/test.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
-use syn::{parse_macro_input, Block, ItemFn, LitStr, Token};
+use syn::{parse_macro_input, ItemFn, LitStr, Token};
 
 use crate::common::{DuplicateError, Keyed, KeyedAttribute};
 use crate::plugin::NvimOxi;
@@ -17,169 +17,30 @@ pub fn test(attrs: TokenStream, item: TokenStream) -> TokenStream {
 
     let plugin_name = Ident::new(&format!("__{test_name}"), Span::call_site());
 
-    let test_body = test_body(&attrs, &plugin_name);
-
-    let plugin_body = plugin_body(&attrs, &block, &sig.output);
+    let ret = &sig.output;
 
     let nvim_oxi = &attrs.nvim_oxi;
 
-    quote! {
-        #[test]
-        fn #test_name() {
-            #test_body
-        }
-
-        #[#nvim_oxi::plugin(nvim_oxi = #nvim_oxi)]
-        fn #plugin_name() -> #nvim_oxi::Object {
-            #plugin_body
-        }
-    }
-    .into()
-}
-
-fn test_body(
-    attrs: &Attributes,
-    plugin_name: &Ident,
-) -> proc_macro2::TokenStream {
-    let nvim_oxi = &attrs.nvim_oxi;
-
-    let cmd = match &attrs.cmd {
-        Some(cmd) => quote! { ["-c", #cmd] },
-        None => quote! { ::core::iter::empty::<&str>() },
+    let extra_cmd = match &attrs.cmd {
+        Some(Cmd { cmd, .. }) => quote! { Some(#cmd) },
+        None => quote! { None },
     };
 
     quote! {
-        let library_name = {
-            let mut s = ::std::string::String::new();
-            s.push_str(::std::env::consts::DLL_PREFIX);
-            s.push_str(env!("CARGO_CRATE_NAME"));
-            s.push_str(::std::env::consts::DLL_SUFFIX);
-            s
-        };
-
-        let manifest_dir = env!("CARGO_MANIFEST_DIR");
-
-        // The full path to the compiled library.
-        let library_path = #nvim_oxi::__test::get_target_dir(manifest_dir.as_ref())
-            .join("debug")
-            .join(library_name);
-
-        if !library_path.exists() {
-            panic!(
-                "Compiled library not found in '{}'. Please run `cargo \
-                 build` before running the tests.",
-                library_path.display()
-            )
+        #[test]
+        fn #test_name() -> ::core::result::Result<(), ::std::string::String> {
+            #nvim_oxi::tests::test_body(stringify!(#plugin_name), #extra_cmd)
         }
 
-        let load_library = format!(
-            "lua local f = package.loadlib([[{}]], 'luaopen_{}'); f()",
-            library_path.display(),
-            stringify!(#plugin_name),
-        );
-
-        let out = ::std::process::Command::new("nvim")
-            .args(["-u", "NONE", "--headless"])
-            .args(["-i", "NONE"])
-            .args(["-c", "set noswapfile"])
-            .args(#cmd)
-            .args(["-c", &load_library])
-            .args(["+quit"])
-            .output()
-            .expect("Couldn't find `nvim` binary in $PATH");
-
-        if out.status.success() {
-            return;
-        }
-
-        let mut stderr = ::std::string::String::from_utf8_lossy(&out.stderr);
-
-        if !stderr.is_empty() {
-            let print_from =
-                // The test failed due to a panic.
-                if stderr.starts_with("thread") {
-                    // Remove the last 2 lines for a cleaner error msg.
-                    stderr = {
-                        let lines = stderr.lines().collect::<Vec<_>>();
-                        let up_to = lines.len().saturating_sub(2);
-                        ::std::borrow::Cow::Owned(lines[..up_to].join("\n"))
-                    };
-
-                    let panicked_at = "panicked at ";
-
-                    stderr.match_indices(panicked_at)
-                        .next()
-                        .map(|(offset, _)| offset + panicked_at.len())
-                        .unwrap_or(0)
-                }
-                // The test failed because an error was returned.
-                else {
-                    0
-                };
-
-            panic!("{}", &stderr[print_from..]);
-        } else if let Some(code) = out.status.code() {
-            panic!("Neovim exited with non-zero exit code: {}", code);
-        } else {
-            panic!("Neovim segfaulted");
+        #[#nvim_oxi::plugin(nvim_oxi = #nvim_oxi)]
+        fn #plugin_name()  {
+            fn __test_fn() #ret {
+                #block
+            }
+            #nvim_oxi::tests::plugin_body(__test_fn)
         }
     }
-}
-
-fn plugin_body(
-    attrs: &Attributes,
-    test_body: &Block,
-    test_return_ty: &syn::ReturnType,
-) -> proc_macro2::TokenStream {
-    if let Some(test_fn) = &attrs.test_fn {
-        let fn_name = &test_fn.name;
-        quote! { #fn_name().into() }
-    } else {
-        quote! {
-            trait __IntoResult {
-                type Error: ::core::fmt::Debug;
-                fn into_result(self) -> ::core::result::Result<(), Self::Error>;
-            }
-
-            impl __IntoResult for () {
-                type Error = ::core::convert::Infallible;
-                fn into_result(self) -> ::core::result::Result<(), Self::Error> {
-                    Ok(())
-                }
-            }
-
-            impl<E: ::core::fmt::Debug> __IntoResult for ::core::result::Result<(), E> {
-                type Error = E;
-                fn into_result(self) -> ::core::result::Result<(), E> {
-                    self
-                }
-            }
-
-            fn __test_fn() #test_return_ty {
-                #test_body
-            }
-
-            let result = ::std::panic::catch_unwind(|| {
-                __IntoResult::into_result(__test_fn())
-            });
-
-            let exit_code = match result {
-                Ok(Ok(())) => 0,
-
-                Ok(Err(err)) => {
-                    eprintln!("{:?}", err);
-                    1
-                },
-
-                Err(panic) => {
-                    eprintln!("{:?}", panic);
-                    1
-                },
-            };
-
-            ::std::process::exit(exit_code)
-        }
-    }
+    .into()
 }
 
 #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,35 +91,6 @@ pub use macros::test;
 pub use types::*;
 #[cfg(feature = "test")]
 #[doc(hidden)]
-pub mod __test {
-    use std::path::{Path, PathBuf};
-
-    pub fn get_target_dir(manifest_dir: &Path) -> PathBuf {
-        use miniserde::json;
-
-        let output = ::std::process::Command::new(
-            ::std::env::var("CARGO")
-                .ok()
-                .unwrap_or_else(|| "cargo".to_string()),
-        )
-        .arg("metadata")
-        .arg("--format-version=1")
-        .arg("--no-deps")
-        .current_dir(manifest_dir)
-        .output()
-        .unwrap();
-
-        let object: json::Object =
-            json::from_str(&String::from_utf8(output.stdout).unwrap())
-                .unwrap();
-
-        let target_dir = match object.get("target_directory").unwrap() {
-            json::Value::String(s) => s,
-            _ => panic!("Must be string value"),
-        };
-
-        target_dir.into()
-    }
-}
+pub mod tests;
 
 pub use toplevel::*;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,295 @@
+use std::any::Any;
+use std::env;
+use std::fmt::{Debug, Display};
+use std::panic::{self, Location};
+use std::path::{Path, PathBuf};
+use std::process::{exit, Command};
+use std::str::FromStr;
+use std::sync::{Arc, OnceLock};
+
+use miniserde::json;
+
+/// Returns the `target` directory in which cargo will place the compiled
+/// artifacts for the crate whose manifest is located at `manifest_dir`.
+pub fn target_dir(manifest_dir: &Path) -> PathBuf {
+    let output = Command::new(
+        env::var("CARGO").ok().unwrap_or_else(|| "cargo".to_owned()),
+    )
+    .arg("metadata")
+    .arg("--format-version=1")
+    .arg("--no-deps")
+    .current_dir(manifest_dir)
+    .output()
+    .unwrap();
+
+    let object: json::Object =
+        json::from_str(&String::from_utf8(output.stdout).unwrap()).unwrap();
+
+    let target_dir = match object.get("target_directory").unwrap() {
+        json::Value::String(s) => s,
+        _ => panic!("must be string value"),
+    };
+
+    target_dir.into()
+}
+
+/// TODO: docs
+pub fn plugin_body<R>(test_body: impl Fn() -> R)
+where
+    R: IntoResult,
+{
+    let panic_info = Arc::new(OnceLock::new());
+
+    {
+        let panic_info = panic_info.clone();
+
+        panic::set_hook(Box::new(move |info| {
+            let payload = info.payload();
+
+            let msg = downcast_display::<&str>(payload)
+                .or_else(|| downcast_display::<String>(payload))
+                .or_else(|| downcast_display::<&String>(payload))
+                .map(ToString::to_string)
+                .unwrap_or_default();
+
+            let info = PanicInfo {
+                msg,
+                file: info.location().map(|l| l.file().to_owned()),
+                line: info.location().map(Location::line),
+                column: info.location().map(Location::column),
+            };
+
+            let _ = panic_info.set(info);
+        }));
+    }
+
+    let result = match panic::catch_unwind(|| test_body().into_result()) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(err)) => Err(Failure::Error(err.to_string())),
+        Err(_) => Err(Failure::Panic(panic_info.get().unwrap())),
+    };
+
+    if let Err(failure) = result {
+        eprintln!("{failure}");
+    }
+
+    exit(result.is_err().into());
+}
+
+/// TODO: docs
+pub fn test_body(
+    plugin_name: &str,
+    extra_cmd: Option<&str>,
+) -> Result<(), String> {
+    let panic_info = Arc::new(OnceLock::new());
+
+    {
+        let panic_info = panic_info.clone();
+        panic::set_hook(Box::new(move |_| {
+            println!("{info}", panic_info.get().unwrap());
+        }));
+    }
+
+    let output = run_nvim_command(plugin_name, extra_cmd)
+        .output()
+        .map_err(ToString::to_string)?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if stderr.is_empty() {
+        let msg = output
+            .status
+            .code()
+            .map(|i| format!("Neovim exited with non-zero exit code: {i}"))
+            .unwrap_or_else(|| String::from("Neovim segfaulted"));
+
+        return Err(msg);
+    }
+
+    let Ok(failure) = Failure::from_str(&stderr) else { return Err(stderr) };
+
+    match failure {
+        Failure::Error(err) => return Err(err),
+        Failure::Panic(info) => {
+            panic_info.set(info).unwrap();
+            panic!()
+        },
+    }
+}
+
+/// TODO: docs
+fn run_nvim_command(plugin_name: &str, extra_cmd: Option<&str>) -> Command {
+    let library_name = {
+        let mut s = ::std::string::String::new();
+        s.push_str(::std::env::consts::DLL_PREFIX);
+        s.push_str(env!("CARGO_CRATE_NAME"));
+        s.push_str(::std::env::consts::DLL_SUFFIX);
+        s
+    };
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+    // The full path to the compiled library.
+    let library_path =
+        target_dir(manifest_dir.as_ref()).join("debug").join(library_name);
+
+    if !library_path.exists() {
+        panic!(
+            "Compiled library not found in '{}'. Please run `cargo build` \
+             before running the tests.",
+            library_path.display()
+        )
+    }
+
+    let load_library = format!(
+        "lua local f = package.loadlib([[{}]], 'luaopen_{}'); f()",
+        library_path.display(),
+        stringify!(plugin_name),
+    );
+
+    Command::new("nvim")
+        .args(["-u", "NONE", "--headless"])
+        .args(["-i", "NONE"])
+        .args(["-c", "set noswapfile"])
+        .args(extra_cmd.map(|cmd| ["-c", cmd]).unwrap_or_default())
+        .args(["-c", &load_library])
+        .args(["+quit"])
+}
+
+struct PanicInfo {
+    msg: String,
+    file: Option<String>,
+    line: Option<u32>,
+    column: Option<u32>,
+}
+
+impl Debug for PanicInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "panic:{self.msg}")?;
+
+        if let Some(file) = &self.file {
+            write!(f, "\nfile:{file}")?;
+        }
+
+        if let Some(line) = self.line {
+            write!(f, "\nline:{line}")?;
+        }
+
+        if let Some(column) = self.column {
+            write!(f, "\ncolumn:{column}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for PanicInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // thread 'tests::it_works' panicked at src/lib.rs:15:9:
+        // AA
+
+        write!(f, "thread panicked")?;
+
+        if let Some(file) = &self.file {
+            write!(f, " at {file}")?;
+
+            if let (Some(line), Some(col)) = (self.line, self.column) {
+                write!(f, ":{line}:{col}")?;
+            }
+        }
+
+        write!(f, ":\n{}", self.msg)?;
+
+        Ok(())
+    }
+}
+
+impl FromStr for PanicInfo {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut info = PanicInfo {
+            msg: s.to_owned(),
+            file: None,
+            line: None,
+            column: None,
+        };
+
+        let mut lines = s.lines();
+
+        let first = lines.next().ok_or(())?;
+        let (_, msg) = first.split_once("panic:").ok_or(())?;
+        info.msg = msg.trim().to_owned();
+
+        let second = lines.next().ok_or(())?;
+        let (_, file) = second.split_once("file:").ok_or(())?;
+        info.file = Some(file.trim().to_owned());
+
+        let third = lines.next().ok_or(())?;
+        let (_, line) = third.split_once("line:").ok_or(())?;
+        info.line = Some(line.trim().parse().map_err(|_| ())?);
+
+        let fourth = lines.next().ok_or(())?;
+        let (_, column) = fourth.split_once("column:").ok_or(())?;
+        info.column = Some(column.trim().parse().map_err(|_| ())?);
+
+        Ok(info)
+    }
+}
+
+enum Failure {
+    Error(String),
+    Panic(PanicInfo),
+}
+
+impl Display for Failure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Failure::Error(err) => write!(f, "error:{err}"),
+            Failure::Panic(info) => write!(f, "{info:?}"),
+        }
+    }
+}
+
+impl FromStr for Failure {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once("error:") {
+            Some((_, msg)) => Ok(Failure::Error(msg.trim().to_owned())),
+            None => PanicInfo::from_str(s).map(Self::Panic),
+        }
+    }
+}
+
+pub trait IntoResult {
+    type Error: Display;
+
+    fn into_result(self) -> Result<(), Self::Error>;
+}
+
+impl IntoResult for () {
+    type Error = std::convert::Infallible;
+
+    fn into_result(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl<E: Display> IntoResult for Result<(), E> {
+    type Error = E;
+
+    fn into_result(self) -> Result<(), E> {
+        self
+    }
+}
+
+fn downcast_display<T: Any + Display>(
+    value: &dyn Any,
+) -> Option<&dyn Display> {
+    value.downcast_ref::<T>().map(|msg| msg as &dyn Display)
+}

--- a/tests/src/api/buffer.rs
+++ b/tests/src/api/buffer.rs
@@ -254,7 +254,7 @@ fn buf_set_get_del_var() {
 
 #[nvim::test]
 fn buf_set_get_name() {
-    let mut buf = Buffer::current();
+    let mut buf = api::create_buf(true, false).unwrap();
 
     assert_eq!("", buf.get_name().unwrap().display().to_string());
 

--- a/tests/src/api/global.rs
+++ b/tests/src/api/global.rs
@@ -169,7 +169,8 @@ fn set_get_del_keymap() {
 
 #[oxi::test]
 fn set_get_del_mark() {
-    let mut buf = Buffer::current();
+    let mut buf = api::create_buf(true, false).unwrap();
+
     let opts = SetMarkOpts::default();
 
     let res = buf.set_mark('A', 1, 0, &opts);

--- a/tests/src/api/vimscript.rs
+++ b/tests/src/api/vimscript.rs
@@ -9,7 +9,7 @@ fn call_function() {
 }
 
 #[cfg(not(feature = "neovim-0-8"))]
-#[oxi::test]
+#[oxi::test(cmd = "set autoread")] // getting `W13` warnings otherwise
 fn cmd_basic() {
     let cmd = "checktime";
     let infos = CmdInfos::builder().cmd(cmd).build();


### PR DESCRIPTION
Improves the output message when the test fails.

```rust
#[oxi::test]
fn foo() {
    panic!();
}

#[oxi::test]
fn bar() -> Result<(), String> {
    Err("bar".into())
}
```

Before:

```
---- api::autocmd::foo stdout ----
thread 'api::autocmd::foo' panicked at src/api/autocmd.rs:5:1:
src/api/autocmd.rs:7:5:
explicit panic
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- api::autocmd::bar stdout ----
thread 'api::autocmd::bar' panicked at src/api/autocmd.rs:10:1:
"bar"

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:

```
---- api::autocmd::foo stdout ----
thread '<unnamed>' panicked at src/api/autocmd.rs:7:5:
explicit panic

---- api::autocmd::bar stdout ----
Error: "bar"
```