### PR TITLE
api(win_config): add nightly open win split support

### DIFF
--- a/crates/api/src/extmark.rs
+++ b/crates/api/src/extmark.rs
@@ -291,32 +291,32 @@ impl Buffer {
 }
 
 impl crate::Window {
-    /// Binding to [`nvim_win_add_ns()`][1].
+    /// Binding to [`nvim__win_add_ns()`][1].
     ///
     /// Adds the namespace scope to the window, returning `true` if the
     /// namespace was added, and `false` otherwise.
     ///
-    /// [1]: https://neovim.io/doc/user/api.html#nvim_win_add_ns()
+    /// [1]: https://neovim.io/doc/user/api.html#nvim__win_add_ns()
     #[cfg(feature = "neovim-nightly")]
     #[cfg_attr(docsrs, doc(cfg(feature = "neovim-nightly")))]
     pub fn add_ns(&mut self, ns_id: u32) -> Result<bool> {
         let mut err = nvim::Error::new();
         let was_added =
-            unsafe { nvim_win_add_ns(self.0, ns_id as Integer, &mut err) };
+            unsafe { nvim__win_add_ns(self.0, ns_id as Integer, &mut err) };
         choose!(err, Ok(was_added))
     }
 
-    /// Binding to [`nvim_win_get_ns()`][1].
+    /// Binding to [`nvim__win_get_ns()`][1].
     ///
     /// Gets all the namespaces scopes associated with a window.
     ///
-    /// [1]: https://neovim.io/doc/user/api.html#nvim_win_get_ns()
+    /// [1]: https://neovim.io/doc/user/api.html#nvim__win_get_ns()
     #[cfg(feature = "neovim-nightly")]
     #[cfg_attr(docsrs, doc(cfg(feature = "neovim-nightly")))]
     pub fn get_ns(&self) -> Result<impl SuperIterator<u32>> {
         let mut err = nvim::Error::new();
         let namespaces =
-            unsafe { nvim_win_get_ns(self.0, types::arena(), &mut err) };
+            unsafe { nvim__win_get_ns(self.0, types::arena(), &mut err) };
         choose!(
             err,
             Ok(namespaces
@@ -325,18 +325,18 @@ impl crate::Window {
         )
     }
 
-    /// Binding to [`nvim_win_remove_ns()`][1].
+    /// Binding to [`nvim__win_del_ns()`][1].
     ///
     /// Removes the namespace scope from the window, returning `true` if the
     /// namespace was removed, and `false` otherwise.
     ///
-    /// [1]: https://neovim.io/doc/user/api.html#nvim_win_remove_ns()
+    /// [1]: https://neovim.io/doc/user/api.html#nvim__win_del_ns()
     #[cfg(feature = "neovim-nightly")]
     #[cfg_attr(docsrs, doc(cfg(feature = "neovim-nightly")))]
-    pub fn remove_ns(&mut self, ns_id: u32) -> Result<bool> {
+    pub fn del_ns(&mut self, ns_id: u32) -> Result<bool> {
         let mut err = nvim::Error::new();
         let was_removed =
-            unsafe { nvim_win_remove_ns(self.0, ns_id as Integer, &mut err) };
+            unsafe { nvim__win_del_ns(self.0, ns_id as Integer, &mut err) };
         choose!(err, Ok(was_removed))
     }
 }

--- a/crates/api/src/ffi/extmark.rs
+++ b/crates/api/src/ffi/extmark.rs
@@ -83,25 +83,25 @@ extern "C" {
         err: *mut Error,
     );
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/extmark.c#L1223
+    // https://github.com/neovim/neovim/blob/master/src/nvim/api/extmark.c#L1226
     #[cfg(feature = "neovim-nightly")]
-    pub(crate) fn nvim_win_add_ns(
+    pub(crate) fn nvim__win_add_ns(
         window: WinHandle,
         ns_id: Integer,
         err: *mut Error,
     ) -> Boolean;
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/extmark.c#L1246
+    // https://github.com/neovim/neovim/blob/master/src/nvim/api/extmark.c#L1252
     #[cfg(feature = "neovim-nightly")]
-    pub(crate) fn nvim_win_get_ns(
+    pub(crate) fn nvim__win_get_ns(
         window: WinHandle,
         arena: *mut Arena,
         err: *mut Error,
     ) -> Array;
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/extmark.c#L1268
+    // https://github.com/neovim/neovim/blob/master/src/nvim/api/extmark.c#L1275
     #[cfg(feature = "neovim-nightly")]
-    pub(crate) fn nvim_win_remove_ns(
+    pub(crate) fn nvim__win_del_ns(
         window: WinHandle,
         ns_id: Integer,
         err: *mut Error,

--- a/crates/api/src/types/split_direction.rs
+++ b/crates/api/src/types/split_direction.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use types::String as NvimString;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -7,4 +8,16 @@ pub enum SplitDirection {
     Below,
     Left,
     Right,
+}
+
+impl From<SplitDirection> for NvimString {
+    fn from(direction: SplitDirection) -> Self {
+        match direction {
+            SplitDirection::Above => "above",
+            SplitDirection::Below => "below",
+            SplitDirection::Left => "left",
+            SplitDirection::Right => "right",
+        }
+        .into()
+    }
 }

--- a/crates/api/src/types/window_relative_to.rs
+++ b/crates/api/src/types/window_relative_to.rs
@@ -5,6 +5,7 @@ use crate::Window;
 
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
 /// Specifies what a floating window is positioned relative to.
 pub enum WindowRelativeTo {
     /// Positions the window relative to the global Neovim editor grid.

--- a/crates/api/src/types/window_relative_to.rs
+++ b/crates/api/src/types/window_relative_to.rs
@@ -1,25 +1,24 @@
-use std::fmt;
-
-use serde::de;
+use serde::Deserialize;
 use types::{Object, String as NvimString};
 
 use crate::Window;
 
 #[non_exhaustive]
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Deserialize)]
 /// Specifies what a floating window is positioned relative to.
 pub enum WindowRelativeTo {
     /// Positions the window relative to the global Neovim editor grid.
     Editor,
-
-    /// Positions the window relative to another window.
-    Window(Window),
 
     /// Positions the window relative to the current cursor position.
     Cursor,
 
     /// Positions the window relative to the current mouse cursor position..
     Mouse,
+
+    /// Positions the window relative to another window.
+    #[serde(untagged)]
+    Window(Window),
 }
 
 impl From<WindowRelativeTo> for NvimString {
@@ -37,48 +36,5 @@ impl From<WindowRelativeTo> for NvimString {
 impl From<&WindowRelativeTo> for Object {
     fn from(pos: &WindowRelativeTo) -> Self {
         NvimString::from(pos.clone()).into()
-    }
-}
-
-// https://github.com/serde-rs/serde/issues/1402
-impl<'de> de::Deserialize<'de> for WindowRelativeTo {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        struct WindowRelativeToVisitor;
-
-        impl<'de> de::Visitor<'de> for WindowRelativeToVisitor {
-            type Value = WindowRelativeTo;
-
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("\"editor\", \"cursor\" or \"mouse\"")
-            }
-
-            fn visit_i64<E>(self, n: i64) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                let handle = i32::try_from(n).unwrap();
-                Ok(WindowRelativeTo::Window(handle.into()))
-            }
-
-            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                match s {
-                    "editor" => Ok(WindowRelativeTo::Editor),
-                    "cursor" => Ok(WindowRelativeTo::Cursor),
-                    "mouse" => Ok(WindowRelativeTo::Mouse),
-                    _ => Err(E::invalid_value(
-                        de::Unexpected::Str(s),
-                        &"\"editor\", \"cursor\" or \"mouse\"",
-                    )),
-                }
-            }
-        }
-
-        deserializer.deserialize_str(WindowRelativeToVisitor)
     }
 }

--- a/flake.lock
+++ b/flake.lock
@@ -18,17 +18,14 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
+        "nixpkgs-lib": ["neovim-nightly-overlay", "nixpkgs"]
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
         "type": "github"
       },
       "original": {
@@ -46,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -81,11 +78,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -97,17 +94,14 @@
     "hercules-ci-effects": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["neovim-nightly-overlay", "nixpkgs"]
       },
       "locked": {
-        "lastModified": 1710478346,
-        "narHash": "sha256-Xjf8BdnQG0tLhPMlqQdwCIjOp7Teox0DP3N/jjyiGM4=",
+        "lastModified": 1713898448,
+        "narHash": "sha256-6q6ojsp/Z9P2goqnxyfCSzFOD92T3Uobmj8oVAicUOs=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "64e7763d72c1e4c1e5e6472640615b6ae2d40fbf",
+        "rev": "c0302ec12d569532a6b6bd218f698bc402e93adc",
         "type": "github"
       },
       "original": {
@@ -119,18 +113,15 @@
     "neovim-flake": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
+        "nixpkgs": ["neovim-nightly-overlay", "nixpkgs"]
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1713051308,
-        "narHash": "sha256-DaaiUHENmPl1vPrQIJY7sl/LspPBQ/XiLIVeLfqpkKw=",
+        "lastModified": 1715551630,
+        "narHash": "sha256-hNuCVU96sDo1zmnt0OSLRYv56f2CrH9XrftPsK8fMWo=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a92822835521574710a830a7de0e692bf7517fb8",
+        "rev": "c7958356bef304320d86cd541d0de8db968c6cc8",
         "type": "github"
       },
       "original": {
@@ -146,16 +137,14 @@
         "flake-parts": "flake-parts",
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-flake": "neovim-flake",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
-        "lastModified": 1713053047,
-        "narHash": "sha256-x17vugcgPuF+w5MpeYUbOlmUw/8tz7W4UetHKCode0E=",
+        "lastModified": 1715558773,
+        "narHash": "sha256-yyKzLgpCjnY6Nns5O9M13LgNtevO5UCenQr61BO0AiI=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "8fa4fbe03aa7475441dd1b9c62e36feea083bfb0",
+        "rev": "2d293e623b20fc71d94c3c96d8fc47e280edd1c7",
         "type": "github"
       },
       "original": {
@@ -167,11 +156,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712791164,
-        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "lastModified": 1715534503,
+        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
         "type": "github"
       },
       "original": {

--- a/tests/src/api/extmark.rs
+++ b/tests/src/api/extmark.rs
@@ -241,5 +241,5 @@ fn extmark_win_add_get_remove_ns() {
     let ns = api::create_namespace("test");
     assert!(win.add_ns(ns).unwrap());
     assert_eq!(win.get_ns().unwrap().collect::<Vec<_>>(), [ns]);
-    assert!(win.remove_ns(ns).unwrap());
+    assert!(win.del_ns(ns).unwrap());
 }

--- a/tests/src/api/win_config.rs
+++ b/tests/src/api/win_config.rs
@@ -32,11 +32,11 @@ fn open_win_basic_config() {
     assert!(got.is_ok(), "{got:?}");
 
     let got = got.unwrap();
-    assert_eq!(config.relative, got.relative);
-    assert_eq!(config.height, got.height);
-    assert_eq!(config.width, got.width);
-    assert_eq!(config.row, got.row);
-    assert_eq!(config.col, got.col);
+    assert_eq!(config.relative.unwrap(), got.relative.unwrap());
+    assert_eq!(config.height.unwrap(), got.height.unwrap());
+    assert_eq!(config.width.unwrap(), got.width.unwrap());
+    assert_eq!(config.row.unwrap(), got.row.unwrap());
+    assert_eq!(config.col.unwrap(), got.col.unwrap());
 }
 
 #[oxi::test]
@@ -69,12 +69,12 @@ fn open_win_full_config() {
     assert!(got.is_ok(), "{got:?}");
 
     let got = got.unwrap();
-    assert_eq!(config.relative, got.relative);
-    assert_eq!(config.height, got.height);
-    assert_eq!(config.width, got.width);
-    assert_eq!(config.row, got.row);
-    assert_eq!(config.col, got.col);
-    assert_eq!(config.border, got.border);
+    assert_eq!(config.relative.unwrap(), got.relative.unwrap());
+    assert_eq!(config.height.unwrap(), got.height.unwrap());
+    assert_eq!(config.width.unwrap(), got.width.unwrap());
+    assert_eq!(config.row.unwrap(), got.row.unwrap());
+    assert_eq!(config.col.unwrap(), got.col.unwrap());
+    assert_eq!(config.border.unwrap(), got.border.unwrap());
 }
 
 #[cfg(feature = "neovim-nightly")]
@@ -97,10 +97,7 @@ fn open_split_win() {
     assert!(got.is_ok(), "{got:?}");
 
     let got = got.unwrap();
-    // `vim.api.nvim_win_get_config` does not seem
-    // to ever return `vertical` field
-    // assert_eq!(config.vertical, got.vertical);
-    assert_eq!(config.split, got.split);
+    assert_eq!(config.split.unwrap(), got.split.unwrap());
 
     let new_win = api::get_current_win();
     assert_ne!(old_win, new_win);

--- a/tests/src/api/win_config.rs
+++ b/tests/src/api/win_config.rs
@@ -77,6 +77,35 @@ fn open_win_full_config() {
     assert_eq!(config.border, got.border);
 }
 
+#[cfg(feature = "neovim-nightly")]
+#[oxi::test]
+fn open_split_win() {
+    let buf = api::create_buf(true, true).unwrap();
+    let old_win = api::get_current_win();
+
+    let config = WindowConfig::builder()
+        .vertical(true)
+        .split(SplitDirection::Right)
+        .build();
+
+    let res = api::open_win(&buf, true, &config);
+    assert!(res.is_ok(), "{res:?}");
+
+    let win = res.unwrap();
+
+    let got = win.get_config();
+    assert!(got.is_ok(), "{got:?}");
+
+    let got = got.unwrap();
+    // `vim.api.nvim_win_get_config` does not seem
+    // to ever return `vertical` field
+    // assert_eq!(config.vertical, got.vertical);
+    assert_eq!(config.split, got.split);
+
+    let new_win = api::get_current_win();
+    assert_ne!(old_win, new_win);
+}
+
 #[oxi::test]
 fn set_config() {
     let buf = api::create_buf(true, true).unwrap();


### PR DESCRIPTION
Noticed that new nightly functionality for `nvim_open_win`  that allows to open regular splits is not possible to use with the crate yet. Hopefully it will be of help. 

Also made `WindowRelativeTo` use serde untagged instead of the custom implementation, since there was a comment linking to [this issue](https://github.com/serde-rs/serde/issues/1402).

Please, let me know if I missed something.