### PR TITLE
api: fix `CommandNArgs` `Zero` and `One` int representation

### DIFF
--- a/crates/api/src/types/command_nargs.rs
+++ b/crates/api/src/types/command_nargs.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{ser, Deserialize, Serialize};
 use types::{
     conversion::{self, ToObject},
     serde::Serializer,
@@ -7,9 +7,7 @@ use types::{
 
 /// Number of arguments accepted by a command.
 #[non_exhaustive]
-#[derive(
-    Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize)]
 pub enum CommandNArgs {
     #[default]
     #[serde(rename = "0")]
@@ -26,6 +24,22 @@ pub enum CommandNArgs {
 
     #[serde(rename = "*")]
     Any,
+}
+
+// https://github.com/serde-rs/serde/issues/1773
+impl Serialize for CommandNArgs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        match self {
+            CommandNArgs::Zero => serializer.serialize_i32(0),
+            CommandNArgs::One => serializer.serialize_i32(1),
+            CommandNArgs::ZeroOrOne => serializer.serialize_str("?"),
+            CommandNArgs::OneOrMore => serializer.serialize_str("+"),
+            CommandNArgs::Any => serializer.serialize_str("*"),
+        }
+    }
 }
 
 impl ToObject for CommandNArgs {


### PR DESCRIPTION
`create_user_command` expects `0` and `1` nargs option to be represented as integers. Currently it is impossible to use any serde proc macro to solve this problem. 

I managed to reproduce the following error both on stable and nightly:
`Value of type myname::setup::types::Config couldn't be pushed on the stack: unexpected myname.nvim error: Validation("Invalid \'nargs\': \'1\'").`

**Stable**
```
NVIM v0.9.5
Build type: Release
LuaJIT 2.1.1693350652
```

**Nightly**
```
NVIM v0.10.0-dev-ca735c7
Build type: Release
LuaJIT 2.1.1693350652
```