### PR TITLE
api: add a `mouse` field to `Window{Config,Opts}` on nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - a `String::to_str()` method which returns a `&str` if the string contains
   valid UTF-8 data;
 
+- a `WindowConfig::mouse` field and a `WindowOptsBuilder::mouse()` method
+  on nightly ([#189](https://github.com/noib3/nvim-oxi/pull/189));
+
 ### Changed
 
 - `nvim_oxi::api::echo` is now generic over the highlight group type instead of

--- a/crates/api/src/types/window_config.rs
+++ b/crates/api/src/types/window_config.rs
@@ -75,6 +75,11 @@ pub struct WindowConfig {
     )]
     pub hide: Option<bool>,
 
+    #[cfg_attr(docsrs, doc(cfg(feature = "neovim-nightly")))]
+    #[cfg(feature = "neovim-nightly")] // On 0.10 and nightly.
+    #[serde(default)]
+    pub mouse: bool,
+
     /// If `true` then no buffer-related autocommand events such as `BufEnter`
     /// or `BufLeave` are fired when calling [`open_win`](crate::open_win).
     pub noautocmd: Option<bool>,
@@ -436,6 +441,9 @@ pub struct WindowOpts {
     bufpos: Array,
     external: Boolean,
     focusable: Boolean,
+    #[cfg_attr(docsrs, doc(cfg(feature = "neovim-nightly")))]
+    #[cfg(feature = "neovim-nightly")]
+    mouse: Boolean,
     vertical: Boolean,
     zindex: Integer,
     border: Object,
@@ -500,6 +508,9 @@ impl From<&WindowConfig> for WindowOpts {
         if let Some(focusable) = config.focusable {
             builder.focusable(focusable);
         }
+
+        #[cfg(feature = "neovim-nightly")]
+        builder.mouse(config.mouse);
 
         if let Some(vertical) = config.vertical {
             builder.vertical(vertical);
@@ -567,6 +578,8 @@ impl TryFrom<WindowOpts> for WindowConfig {
             footer_pos,
             height,
             hide,
+            #[cfg(feature = "neovim-nightly")]
+            mouse,
             noautocmd,
             relative,
             row,
@@ -639,6 +652,8 @@ impl TryFrom<WindowOpts> for WindowConfig {
             ))?,
             height: deserialize(height)?,
             hide: deserialize(hide)?,
+            #[cfg(feature = "neovim-nightly")]
+            mouse,
             noautocmd: deserialize(noautocmd)?,
             relative,
             row: deserialize(row)?,


### PR DESCRIPTION
[Upstream](https://github.com/neovim/neovim/commit/9b8907d90508d7b66f025bbd1f5a48a78c5ce035).