### PR TITLE
Cleanup `StringBuilder` methods

### DIFF
--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -204,7 +204,7 @@ impl StringBuilder {
             return;
         }
         let remaining = self.remaining_capacity();
-        if remaining > cap {
+        if remaining >= cap {
             return;
         }
         let needed_space =

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -554,6 +554,23 @@ mod tests {
     }
 
     #[test]
+    fn with_capacity() {
+        let s = StringBuilder::with_capacity(0);
+        assert!(s.inner.data.is_null());
+        assert_eq!(s.cap, 0);
+        assert_eq!(s.inner.len(), 0);
+        s.finish();
+        let s = StringBuilder::with_capacity(1);
+        assert_eq!(s.cap, 2);
+        assert_eq!(s.inner.len(), 0);
+        s.finish();
+        let s = StringBuilder::with_capacity(5);
+        assert_eq!(s.cap, 6);
+        assert_eq!(s.inner.len(), 0);
+        s.finish();
+    }
+
+    #[test]
     fn reserve() {
         let mut sb = StringBuilder::new();
         assert_eq!(sb.cap, 0);

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -231,7 +231,7 @@ impl StringBuilder {
 
     /// Finish building the [`String`]
     #[inline]
-    fn finish(self) -> String {
+    pub fn finish(self) -> String {
         let mut s = String { data: self.inner.data, len: self.inner.len() };
 
         if s.data.is_null() {

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -493,7 +493,8 @@ mod tests {
     #[test]
     fn as_bytes() {
         let s = String::from("hello");
-        assert_eq!(s.as_bytes(), &[b'h', b'e', b'l', b'l', b'o'][..]);
+        assert_eq!(s.as_bytes(), b"hello");
+    }
 
     #[test]
     fn empty_from_bytes() {
@@ -583,18 +584,18 @@ mod tests {
 
     #[test]
     fn builder() {
-        let str = "foo bar";
+        let s = "foo bar";
         let bytes = b"baz foo bar";
 
-        let mut s = StringBuilder::new();
-        s.push_bytes(str.as_bytes());
-        s.push_bytes(bytes);
+        let mut sb = StringBuilder::new();
+        sb.push_bytes(s.as_bytes());
+        sb.push_bytes(bytes);
 
-        assert_eq!(s.inner.len, str.len() + bytes.len());
-        assert_eq!(s.cap, 32); // Allocation size
-        assert_eq!(unsafe { *s.inner.data.add(s.inner.len) }, 0); // Null termination
+        assert_eq!(sb.inner.len, s.len() + bytes.len());
+        assert_eq!(sb.cap, 32); // Allocation size
+        assert_eq!(unsafe { *sb.inner.data.add(sb.inner.len) }, 0); // Null termination
 
-        let s = s.finish();
-        assert_eq!(s.len(), str.len() + bytes.len());
+        let nv_str = sb.finish();
+        assert_eq!(nv_str.len(), s.len() + bytes.len());
     }
 }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -213,7 +213,6 @@ impl StringBuilder {
     ///
     /// Does not allocate if enough space is available.
     pub fn reserve_exact(&mut self, cap: usize) {
-        // + 1 for the null byte
         if cap == 0 {
             return;
         }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -228,6 +228,10 @@ impl StringBuilder {
         self.cap = new_capacity;
     }
 
+    /// Reserve at least "by" bytes.
+    ///
+    /// This is marked unsafe as the allocation size should never be zero for portability reasons.
+    /// A check isn't included as all call sites should already handle the case.
     unsafe fn reserve_raw(&mut self, by: usize) {
         let ptr =
             unsafe { libc::realloc(self.inner.data as *mut ffi::c_void, by) };

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -91,7 +91,6 @@ impl String {
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let mut s = StringBuilder::with_capacity(bytes.len());
         s.push_bytes(bytes);
-
         s.finish()
     }
 
@@ -101,7 +100,8 @@ impl String {
         self.len() == 0
     }
 
-    /// Returns the length of the `String`, *not* including the final null byte.
+    /// Returns the length of the `String`, *not* including the final null
+    /// byte.
     #[inline]
     pub fn len(&self) -> usize {
         self.len
@@ -144,8 +144,8 @@ impl StringBuilder {
 
     /// Push new bytes to the builder.
     ///
-    /// When only pushing bytes once, prefer [`String::from_bytes`] as this method may allocate
-    /// extra space in the buffer.
+    /// When only pushing bytes once, prefer [`String::from_bytes`] as this
+    /// method may allocate extra space in the buffer.
     #[inline]
     pub fn push_bytes(&mut self, bytes: &[u8]) {
         let slice_len = bytes.len();
@@ -189,7 +189,7 @@ impl StringBuilder {
         }
     }
 
-    /// Reserve space for N more bytes.
+    /// Reserve space for `additional` more bytes.
     ///
     /// Does not allocate if enough space is available.
     pub fn reserve(&mut self, additional: usize) {
@@ -202,7 +202,7 @@ impl StringBuilder {
         self.reserve_raw(new_capacity);
     }
 
-    /// Reserve space for exactly N more bytes.
+    /// Reserve space for exactly `additional` more bytes.
     ///
     /// Does not allocate if enough space is available.
     pub fn reserve_exact(&mut self, additional: usize) {
@@ -221,7 +221,8 @@ impl StringBuilder {
                 new_capacity.get(),
             )
         };
-        // realloc may return null if it is unable to allocate the requested memory
+        // `realloc` may return null if it is unable to allocate the requested
+        // memory.
         if ptr.is_null() {
             unable_to_alloc_memory();
         }
@@ -238,8 +239,8 @@ impl StringBuilder {
             debug_assert!(s.is_empty());
             debug_assert_eq!(self.cap, 0);
 
-            // the pointer of `String` should never be null, and it must be terminated by a null
-            // byte.
+            // The pointer of `String` should never be null, and it must be
+            // terminated by a null byte.
             if s.data.is_null() {
                 unsafe {
                     let ptr = libc::malloc(1) as *mut i8;
@@ -260,8 +261,8 @@ impl StringBuilder {
         s
     }
 
-    /// Returns the remaining *usable* capacity, i.e. the remaining capacity minus
-    /// the space reserved for the null terminator.
+    /// Returns the remaining *usable* capacity, i.e. the remaining capacity
+    /// minus the space reserved for the null terminator.
     #[inline(always)]
     fn remaining_capacity(&self) -> usize {
         if self.inner.data.is_null() {
@@ -279,6 +280,8 @@ impl StringBuilder {
         self.cap - self.inner.len() - 1
     }
 
+    /// Returns the minimum capacity needed to allocate `additional` bytes, or
+    /// `None` if the current capacity is already large enough.
     #[inline]
     fn min_capacity_for_additional(
         &self,
@@ -558,16 +561,17 @@ mod tests {
         sb.reserve(10);
         assert_eq!(sb.cap, 16);
 
-        // shouldn't change the pointer address as we have enough space
+        // Shouldn't change the pointer address as we have enough space.
         sb.reserve(10);
         assert_eq!(sb.cap, 16);
         let ptr = sb.inner.data;
         sb.push_bytes(b"Hello World!");
-        // we already allocated the space needed the push above shouldn't change the pointer
+        // We already allocated the space needed the push above shouldn't
+        // change the pointer.
         assert_eq!(sb.inner.data, ptr);
         sb.push_bytes(&[b'a'; 55]);
-        // we shouldn't check the pointer again as the block might be extended instead of being
-        // moved to a different address
+        // We shouldn't check the pointer again as the block might be extended
+        // instead of being moved to a different address.
         assert_eq!(unsafe { *sb.inner.data.add(sb.inner.len) }, 0);
         assert_eq!(sb.cap, 128);
     }
@@ -581,7 +585,8 @@ mod tests {
         sb.push_bytes(b"hi");
         assert_eq!(sb.inner.len(), 2);
 
-        // the space is already allocated, pushing bytes shouldn't change the ptr address
+        // The space is already allocated, pushing bytes shouldn't change the
+        // ptr address.
         assert_eq!(ptr, sb.inner.data);
         sb.push_bytes(b"Hello World!");
         assert_eq!(sb.cap, 16);

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -199,8 +199,8 @@ impl StringBuilder {
     /// Reserve space for N more bytes.
     ///
     /// Does not allocate if enough space is available.
-    pub fn reserve(&mut self, aditional: usize) {
-        let Some(min_capacity) = self.min_capacity_for_additional(aditional)
+    pub fn reserve(&mut self, additional: usize) {
+        let Some(min_capacity) = self.min_capacity_for_additional(additional)
         else {
             return;
         };
@@ -212,8 +212,8 @@ impl StringBuilder {
     /// Reserve space for exactly N more bytes.
     ///
     /// Does not allocate if enough space is available.
-    pub fn reserve_exact(&mut self, aditional: usize) {
-        if let Some(new_capacity) = self.min_capacity_for_additional(aditional)
+    pub fn reserve_exact(&mut self, additional: usize) {
+        if let Some(new_capacity) = self.min_capacity_for_additional(additional)
         {
             self.reserve_raw(new_capacity);
         }
@@ -286,17 +286,17 @@ impl StringBuilder {
     #[inline]
     fn min_capacity_for_additional(
         &self,
-        aditional: usize,
+        additional: usize,
     ) -> Option<NonZeroUsize> {
         let remaining = self.remaining_capacity();
-        if remaining >= aditional {
+        if remaining >= additional {
             return None;
         }
         if self.inner.data.is_null() {
             debug_assert_eq!(self.cap, 0);
-            NonZeroUsize::new(aditional + 1)
+            NonZeroUsize::new(additional + 1)
         } else {
-            NonZeroUsize::new(self.cap + aditional - remaining)
+            NonZeroUsize::new(self.cap + additional - remaining)
         }
     }
 }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -185,7 +185,7 @@ impl StringBuilder {
     /// Does not allocate if enough space is available.
     pub fn reserve(&mut self, cap: usize) {
         // + 1 for the null byte
-        if self.cap - self.inner.len() < cap + 1 {
+        if cap != 0 && self.cap - self.inner.len() < cap + 1 {
             let n = (cap - 1).ilog2() + 1;
             let new_cap = 2_usize.pow(n).max(4);
             self.reserve_exact(new_cap);
@@ -197,7 +197,7 @@ impl StringBuilder {
     /// Does not allocate if enough space is available.
     pub fn reserve_exact(&mut self, cap: usize) {
         // + 1 for the null byte
-        if self.cap - self.inner.len() < cap + 1 {
+        if cap != 0 && self.cap - self.inner.len() < cap + 1 {
             // SAFETY: realloc is legal with null pointers, no need for an extra check.
             self.inner.data = unsafe {
                 libc::realloc(

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -88,8 +88,7 @@ impl String {
     /// by a null byte.
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Self {
-        let mut s = StringBuilder::new();
-        s.reserve_exact(bytes.len());
+        let mut s = StringBuilder::with_capacity(bytes.len());
         s.push_bytes(bytes);
 
         // no need to check if we need to shrink the allocation

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -178,6 +178,14 @@ impl StringBuilder {
 
     /// Initialize [`StringBuilder`] with capacity.
     pub fn with_capacity(cap: usize) -> Self {
+        // Neovim uses `xstrdup` to clone strings, which doesn't support null
+        // pointers.
+        //
+        // For more infos, see https://github.com/noib3/nvim-oxi/pull/211#issuecomment-2566960494
+        //
+        // if cap == 0 {
+        //     return Self::new();
+        // }
         let real_cap = cap + 1;
         let ptr = unsafe { libc::malloc(real_cap) };
         if ptr.is_null() {

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -185,14 +185,7 @@ impl StringBuilder {
         if self.cap - self.inner.len() < cap + 1 {
             let n = (cap - 1).ilog2() + 1;
             let new_cap = 2_usize.pow(n).max(4);
-            // SAFETY: realloc is legal with null pointers, no need for an extra check.
-            self.inner.data = unsafe {
-                libc::realloc(
-                    self.inner.data as *mut _,
-                    self.inner.len() + 1 + new_cap,
-                ) as *mut ffi::c_char
-            };
-            self.cap = self.inner.len() + new_cap;
+            self.reserve_exact(new_cap);
         }
     }
 

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -288,9 +288,6 @@ impl StringBuilder {
         &self,
         aditional: usize,
     ) -> Option<NonZeroUsize> {
-        if aditional == 0 {
-            return None;
-        }
         let remaining = self.remaining_capacity();
         if remaining >= aditional {
             return None;

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -89,6 +89,7 @@ impl String {
     #[inline]
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let mut s = StringBuilder::new();
+        s.reserve_exact(bytes.len());
         s.push_bytes(bytes);
         s.finish()
     }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -237,7 +237,7 @@ impl StringBuilder {
         if s.data.is_null() {
             debug_assert!(s.is_empty());
             debug_assert_eq!(self.cap, 0);
-            
+
             // the pointer of `String` should never be null, and it must be terminated by a null
             // byte.
             if s.data.is_null() {

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -206,7 +206,8 @@ impl StringBuilder {
     ///
     /// Does not allocate if enough space is available.
     pub fn reserve_exact(&mut self, additional: usize) {
-        if let Some(new_capacity) = self.min_capacity_for_additional(additional)
+        if let Some(new_capacity) =
+            self.min_capacity_for_additional(additional)
         {
             self.reserve_raw(new_capacity);
         }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -142,6 +142,9 @@ impl StringBuilder {
     }
 
     /// Push new bytes to the builder.
+    ///
+    /// When only pushing bytes once, prefer [`String::from_bytes`] as this method may allocate
+    /// extra space in the buffer.
     #[inline]
     pub fn push_bytes(&mut self, bytes: &[u8]) {
         let slice_len = bytes.len();

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -178,9 +178,6 @@ impl StringBuilder {
 
     /// Initialize [`StringBuilder`] with capacity.
     pub fn with_capacity(cap: usize) -> Self {
-        if cap == 0 {
-            return Self::new();
-        }
         let real_cap = cap + 1;
         let ptr = unsafe { libc::malloc(real_cap) };
         if ptr.is_null() {

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -207,7 +207,7 @@ impl StringBuilder {
         };
         let new_capacity =
             min_capacity.checked_next_power_of_two().unwrap_or(min_capacity);
-        self.reserve_raw(new_capacity);
+        self.realloc(new_capacity);
     }
 
     /// Reserve space for exactly `additional` more bytes.
@@ -217,12 +217,12 @@ impl StringBuilder {
         if let Some(new_capacity) =
             self.min_capacity_for_additional(additional)
         {
-            self.reserve_raw(new_capacity);
+            self.realloc(new_capacity);
         }
     }
 
-    /// Allocate new_capacity bytes.
-    fn reserve_raw(&mut self, new_capacity: NonZeroUsize) {
+    /// Reallocate the string with the given capacity.
+    fn realloc(&mut self, new_capacity: NonZeroUsize) {
         let ptr = unsafe {
             libc::realloc(
                 self.inner.data as *mut ffi::c_void,

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -148,7 +148,7 @@ impl StringBuilder {
     #[inline]
     pub fn push_bytes(&mut self, bytes: &[u8]) {
         let slice_len = bytes.len();
-        let required_cap = self.inner.len + slice_len + 1;
+        let required_cap = self.inner.len + slice_len;
 
         // Reallocate if pushing the bytes overflows the allocated memory.
         self.reserve(required_cap);

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -161,8 +161,8 @@ impl StringBuilder {
         // Pushing the `bytes` is safe now.
         let new_len = unsafe {
             libc::memcpy(
-                self.inner.data.add(self.inner.len) as *mut _,
-                bytes.as_ptr() as *const _,
+                self.inner.data.add(self.inner.len) as *mut ffi::c_void,
+                bytes.as_ptr() as *const ffi::c_void,
                 slice_len,
             );
 
@@ -282,7 +282,7 @@ impl Drop for String {
 impl Drop for StringBuilder {
     fn drop(&mut self) {
         if !self.inner.data.is_null() {
-            unsafe { libc::free(self.inner.data as *mut _) }
+            unsafe { libc::free(self.inner.data as *mut ffi::c_void) }
         }
     }
 }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -264,7 +264,8 @@ impl StringBuilder {
         s
     }
 
-    /// Returns the remaining capacity including the space for a null byte.
+    /// Returns the remaining *usable* capacity, i.e. the remaining capacity minus
+    /// the space reserved for the null terminator.
     #[inline(always)]
     fn remaining_capacity(&self) -> usize {
         if self.inner.data.is_null() {


### PR DESCRIPTION
I haven't added the necessary tests yet so marking this as draft.

Many of `StringBuilder`'s methods had logic that really should have been their own function with safe wrappers.
This PR moves some logic to their own methods and allows public calls to allocate space without pushing bytes.

This should also reduce the effect of the memory leaks from `String` as `String::from_bytes` will now only allocate the minimal amount needed. This shouldn't change performance in any call site as the capacity is not stored, meaning no length changes are possible once a `String` is constructed. This only helps to reduce the allocated size where arguments require a `String` and a user calls `String::from_bytes`.

As part of the cleanup a redundant null check was removed from `StringBuilder::push_bytes` as `libc::realloc` already handles the null case.

I have made the commit messages to make things are easy to follow. 
Will mark this ready for review once I have added some tests.