### PR TITLE
Fix null-unterminated cstr

### DIFF
--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -187,7 +187,7 @@ impl StringBuilder {
         //     return Self::new();
         // }
         let real_cap = cap + 1;
-        let ptr = unsafe { libc::malloc(real_cap) };
+        let ptr = unsafe { libc::calloc(real_cap, 1) };
         if ptr.is_null() {
             unable_to_alloc_memory();
         }


### PR DESCRIPTION
I got a segfault when using `nvim_oxi::api::notify` on `5.1` dug into the string-builder, and its backing memory is created using `malloc` which does not guarantee a default value for the backing memory. However, c requires that strings are null-terminated, so that code has/had UB.

It's later been changed to a `StringBuilder` but that code has the same issue, allocates `size + 1` bytes of any memory, so the segfaulting issues still persist. 

Using `calloc` instead fixes it. I didn't look around more, but there could be more places lurking where memory is assumed to be zeroed when it isn't.