### PR TITLE
fix soundness problems in String and StringBuilder

### DIFF
--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -20,7 +20,7 @@ use crate::NonOwning;
 #[derive(Eq, Ord, PartialOrd)]
 #[repr(C)]
 pub struct String {
-    // NOTE: strings built by nvim-oxi can never contain a null pointer as they are intended as 
+    // NOTE: strings built by nvim-oxi can never contain a null pointer as they are intended as
     // lua strings in neovim. however a string returned by neovim can have a null pointer so a null
     // check should performed on access
     pub(super) data: *mut ffi::c_char,


### PR DESCRIPTION
There were a few methods where a null pointer was used or the string was not null terminated.

This fixes possible undefined behaviors. To avoid these issues in the future a few assertions were added into `StringBuilder::finish` to ensure that a `String` is never initialized with a null pointer and is always terminated with a null byte. 