### PR TITLE
Use nvim 0.10's `nvim_win_set_hl_ns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@
 - renamed `Object::into_dict_unchecked()` to
   `Object::into_dictionary_unchecked()`;
 
+- renamed `nvim_oxi::api::Window::set_hl` to `nvim_oxi::api::Window::set_hl_ns`
+  ([#220](https://github.com/noib3/nvim-oxi/pull/220))
+
 ### Removed
 
 - the `SetHighlightOptsBuilder::global_link()` method. Use

--- a/crates/api/src/ffi/window.rs
+++ b/crates/api/src/ffi/window.rs
@@ -108,9 +108,9 @@ extern "C" {
         err: *mut Error,
     );
 
-    // https://github.com/neovim/neovim/blob/master/src/nvim/api/window.c#L456
+    // https://github.com/neovim/neovim/blob/release-0.10/src/nvim/api/window.c#L464
     #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
-    pub(crate) fn nvim_win_set_hl(
+    pub(crate) fn nvim_win_set_hl_ns(
         win: WinHandle,
         ns_id: Integer,
         err: *mut Error,

--- a/crates/api/src/window.rs
+++ b/crates/api/src/window.rs
@@ -348,7 +348,7 @@ impl Window {
         choose!(err, ())
     }
 
-    /// Binding to [`nvim_win_set_hl()`][1].
+    /// Binding to [`nvim_win_set_hl_ns()`][1].
     ///
     /// Sets the highlight namespace for this window. This will the highlights
     /// defined with [`set_hl`](crate::set_hl) for the given namespace, but
@@ -364,7 +364,7 @@ impl Window {
     )]
     pub fn set_hl(&mut self, ns_id: u32) -> Result<()> {
         let mut err = nvim::Error::new();
-        unsafe { nvim_win_set_hl(self.0, ns_id.into(), &mut err) };
+        unsafe { nvim_win_set_hl_ns(self.0, ns_id.into(), &mut err) };
         choose!(err, ())
     }
 

--- a/crates/api/src/window.rs
+++ b/crates/api/src/window.rs
@@ -356,13 +356,13 @@ impl Window {
     ///
     /// This takes precedence over the `winhighlight` option.
     ///
-    /// [1]: https://neovim.io/doc/user/api.html#nvim_win_set_hl()
+    /// [1]: https://neovim.io/doc/user/api.html#nvim_win_set_hl_ns()
     #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
     #[cfg_attr(
         docsrs,
         doc(cfg(any(feature = "neovim-0-10", feature = "neovim-nightly")))
     )]
-    pub fn set_hl(&mut self, ns_id: u32) -> Result<()> {
+    pub fn set_hl_ns(&mut self, ns_id: u32) -> Result<()> {
         let mut err = nvim::Error::new();
         unsafe { nvim_win_set_hl_ns(self.0, ns_id.into(), &mut err) };
         choose!(err, ())


### PR DESCRIPTION
# Uses `nvim_win_set_hl_ns` instead of `nvim_win_set_hl`
I think maybe the symbol was misspelled or taken from an older nvim version `nvim_win_set_hl` doesn't exist, 
I changed to doc-link to go to the 0.10 release, but it looks the same on* current neovim main.

If you try to run the old version neovim will fail to load the `.so` because of a missing symbol (`nvim_win_set_hl`)