### PR TITLE
fix: Use platform specific c_char in malloc cast

### DIFF
--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -251,7 +251,7 @@ impl StringBuilder {
             // terminated by a null byte.
             if s.data.is_null() {
                 unsafe {
-                    let ptr = libc::malloc(1) as *mut std::ffi::c_char;
+                    let ptr = libc::malloc(1) as *mut ffi::c_char;
                     if ptr.is_null() {
                         unable_to_alloc_memory();
                     }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -251,7 +251,7 @@ impl StringBuilder {
             // terminated by a null byte.
             if s.data.is_null() {
                 unsafe {
-                    let ptr = libc::malloc(1) as *mut i8;
+                    let ptr = libc::malloc(1) as *mut std::ffi::c_char;
                     if ptr.is_null() {
                         unable_to_alloc_memory();
                     }


### PR DESCRIPTION
Doesn't compile on `aarch64` because of a pointer cast
```bash
error[E0308]: mismatched types
   --> /cargo/git/checkouts/nvim-oxi-3da5ffeaab66eb2e/a890ce4/crates/types/src/string.rs:260:30
    |
260 |                     s.data = ptr;
    |                     ------   ^^^ expected `*mut u8`, found `*mut i8`
    |                     |
    |                     expected due to the type of this binding
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`
```
changing it to `c_char` to be more platform-agnostic fixes it