### PR TITLE
Init changes

### DIFF
--- a/crates/libuv/src/loop.rs
+++ b/crates/libuv/src/loop.rs
@@ -14,8 +14,9 @@ thread_local! {
 /// exposed by this crate or there will be segfaults.
 #[doc(hidden)]
 pub unsafe fn init(lua_state: *mut State) {
-    LOOP.with(|uv_loop| uv_loop.set(ffi::luv_loop(lua_state)))
-        .unwrap_unchecked();
+    LOOP.with(|uv_loop| {
+        let _ = uv_loop.set(ffi::luv_loop(lua_state));
+    });
 }
 
 /// Executes a function with access to the libuv loop.

--- a/crates/luajit/src/state.rs
+++ b/crates/luajit/src/state.rs
@@ -11,7 +11,9 @@ thread_local! {
 /// NOTE: this function **must** be called before calling any other function
 /// exposed by this crate or there will be segfaults.
 pub unsafe fn init(lstate: *mut State) {
-    LUA.with(|lua| lua.set(lstate).unwrap_unchecked());
+    LUA.with(|lua| {
+        let _ = lua.set(lstate);
+    });
 }
 
 /// Executes a function with access to the Lua state.

--- a/crates/types/src/arena.rs
+++ b/crates/types/src/arena.rs
@@ -26,19 +26,13 @@ impl Arena {
 
 /// Initializes the [`Arena`].
 ///
-/// This should be called exactly once during the lifetime of the plugin and as
-/// soon as it is loaded.
-///
-/// # Panics
-///
-/// Panics if this function was already called.
+/// This should be called as soon as the plugin is loaded.
+/// Subsequent calls will be ignored.
 #[doc(hidden)]
 #[inline]
 pub fn arena_init() {
     ARENA.with(|arena| {
-        if arena.set(Arena::new()).is_err() {
-            panic!("Arena is already initialized");
-        }
+        let _ = arena.set(Arena::new());
     });
 }
 

--- a/crates/types/src/arena.rs
+++ b/crates/types/src/arena.rs
@@ -27,7 +27,6 @@ impl Arena {
 /// Initializes the [`Arena`].
 ///
 /// This should be called as soon as the plugin is loaded.
-/// Subsequent calls will be ignored.
 #[doc(hidden)]
 #[inline]
 pub fn arena_init() {

--- a/crates/types/src/kvec.rs
+++ b/crates/types/src/kvec.rs
@@ -289,7 +289,7 @@ impl<T> Iterator for IntoIter<T> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if std::ptr::eq(self.start, self.end) {
+        if ptr::eq(self.start, self.end) {
             None
         } else {
             let current = self.start;
@@ -315,7 +315,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 impl<T> DoubleEndedIterator for IntoIter<T> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        if std::ptr::eq(self.start, self.end) {
+        if ptr::eq(self.start, self.end) {
             None
         } else {
             self.end = unsafe { self.end.offset(-1) };
@@ -330,7 +330,7 @@ impl<T> Drop for IntoIter<T> {
     #[inline]
     fn drop(&mut self) {
         // Drop each element before freeing the original `KVec`.
-        while !std::ptr::eq(self.start, self.end) {
+        while !ptr::eq(self.start, self.end) {
             let current = self.start;
             self.start = unsafe { self.start.offset(1) };
             unsafe { ptr::drop_in_place(current) };

--- a/crates/types/src/kvec.rs
+++ b/crates/types/src/kvec.rs
@@ -289,7 +289,7 @@ impl<T> Iterator for IntoIter<T> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.start == self.end {
+        if std::ptr::eq(self.start, self.end) {
             None
         } else {
             let current = self.start;
@@ -315,7 +315,7 @@ impl<T> ExactSizeIterator for IntoIter<T> {
 impl<T> DoubleEndedIterator for IntoIter<T> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.start == self.end {
+        if std::ptr::eq(self.start, self.end) {
             None
         } else {
             self.end = unsafe { self.end.offset(-1) };
@@ -330,7 +330,7 @@ impl<T> Drop for IntoIter<T> {
     #[inline]
     fn drop(&mut self) {
         // Drop each element before freeing the original `KVec`.
-        while self.start != self.end {
+        while !std::ptr::eq(self.start, self.end) {
             let current = self.start;
             self.start = unsafe { self.start.offset(1) };
             unsafe { ptr::drop_in_place(current) };


### PR DESCRIPTION
Changed the `types::arena_init()`, `luajit::init()` and `libuv::init()` so they can be called more than once, throwing away any subsequent call. This allows the plugin to be required more than once without crashing Neovim.

Closes #86.