### PR TITLE
Add `NvimStr`

### DIFF
--- a/crates/api/src/autocmd.rs
+++ b/crates/api/src/autocmd.rs
@@ -40,7 +40,7 @@ pub fn create_augroup(name: &str, opts: &CreateAugroupOpts) -> Result<u32> {
     let id = unsafe {
         nvim_create_augroup(
             LUA_INTERNAL_CALL,
-            name.non_owning(),
+            name.as_nvim_str(),
             opts,
             &mut err,
         )
@@ -94,7 +94,7 @@ pub fn del_augroup_by_id(id: u32) -> Result<()> {
 pub fn del_augroup_by_name(name: &str) -> Result<()> {
     let name = nvim::String::from(name);
     let mut err = nvim::Error::new();
-    unsafe { nvim_del_augroup_by_name(name.non_owning(), &mut err) };
+    unsafe { nvim_del_augroup_by_name(name.as_nvim_str(), &mut err) };
     choose!(err, ())
 }
 

--- a/crates/api/src/buffer.rs
+++ b/crates/api/src/buffer.rs
@@ -201,8 +201,8 @@ impl Buffer {
             nvim_buf_del_keymap(
                 LUA_INTERNAL_CALL,
                 self.0,
-                mode.non_owning(),
-                lhs.non_owning(),
+                mode.as_nvim_str(),
+                lhs.as_nvim_str(),
                 &mut err,
             )
         };
@@ -218,7 +218,7 @@ impl Buffer {
         let mut err = nvim::Error::new();
         let name = nvim::String::from(name);
         let was_deleted =
-            unsafe { nvim_buf_del_mark(self.0, name.non_owning(), &mut err) };
+            unsafe { nvim_buf_del_mark(self.0, name.as_nvim_str(), &mut err) };
         choose!(
             err,
             match was_deleted {
@@ -237,7 +237,7 @@ impl Buffer {
     pub fn del_var(&mut self, name: &str) -> Result<()> {
         let mut err = nvim::Error::new();
         let name = nvim::String::from(name);
-        unsafe { nvim_buf_del_var(self.0, name.non_owning(), &mut err) };
+        unsafe { nvim_buf_del_var(self.0, name.as_nvim_str(), &mut err) };
         choose!(err, ())
     }
 
@@ -288,7 +288,7 @@ impl Buffer {
         let maps = unsafe {
             nvim_buf_get_keymap(
                 self.0,
-                mode.non_owning(),
+                mode.as_nvim_str(),
                 #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
                 types::arena(),
                 &mut err,
@@ -360,7 +360,7 @@ impl Buffer {
         let mark = unsafe {
             nvim_buf_get_mark(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
                 types::arena(),
                 &mut err,
@@ -468,7 +468,7 @@ impl Buffer {
         let obj = unsafe {
             nvim_buf_get_var(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
                 types::arena(),
                 &mut err,
@@ -527,9 +527,9 @@ impl Buffer {
             nvim_buf_set_keymap(
                 LUA_INTERNAL_CALL,
                 self.0,
-                mode.non_owning(),
-                lhs.non_owning(),
-                rhs.non_owning(),
+                mode.as_nvim_str(),
+                lhs.as_nvim_str(),
+                rhs.as_nvim_str(),
                 opts,
                 &mut err,
             )
@@ -593,7 +593,7 @@ impl Buffer {
         let mark_was_set = unsafe {
             nvim_buf_set_mark(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 line.try_into()?,
                 col.try_into()?,
                 #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
@@ -620,7 +620,7 @@ impl Buffer {
     pub fn set_name<Name: AsRef<Path>>(&mut self, name: Name) -> Result<()> {
         let name = nvim::String::from(name.as_ref());
         let mut err = nvim::Error::new();
-        unsafe { nvim_buf_set_name(self.0, name.non_owning(), &mut err) };
+        unsafe { nvim_buf_set_name(self.0, name.as_nvim_str(), &mut err) };
         choose!(err, ())
     }
 
@@ -679,7 +679,7 @@ impl Buffer {
         unsafe {
             nvim_buf_set_var(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 value.to_object()?.non_owning(),
                 &mut err,
             )

--- a/crates/api/src/command.rs
+++ b/crates/api/src/command.rs
@@ -51,7 +51,7 @@ where
     unsafe {
         nvim_create_user_command(
             LUA_INTERNAL_CALL,
-            name.non_owning(),
+            name.as_nvim_str(),
             command.non_owning(),
             opts,
             &mut err,
@@ -69,7 +69,7 @@ where
 pub fn del_user_command(name: &str) -> Result<()> {
     let name = nvim::String::from(name);
     let mut err = nvim::Error::new();
-    unsafe { nvim_del_user_command(name.non_owning(), &mut err) };
+    unsafe { nvim_del_user_command(name.as_nvim_str(), &mut err) };
     choose!(err, ())
 }
 
@@ -113,7 +113,7 @@ pub fn parse_cmd(src: &str, opts: &ParseCmdOpts) -> Result<CmdInfos> {
 
     let out = unsafe {
         nvim_parse_cmd(
-            src.non_owning(),
+            src.as_nvim_str(),
             #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
             opts.non_owning(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
@@ -159,7 +159,7 @@ impl Buffer {
                 ))]
                 LUA_INTERNAL_CALL,
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 command.non_owning(),
                 opts,
                 &mut err,
@@ -179,7 +179,7 @@ impl Buffer {
         let mut err = nvim::Error::new();
         let name = nvim::String::from(name);
         unsafe {
-            nvim_buf_del_user_command(self.0, name.non_owning(), &mut err)
+            nvim_buf_del_user_command(self.0, name.as_nvim_str(), &mut err)
         };
         choose!(err, ())
     }

--- a/crates/api/src/deprecated.rs
+++ b/crates/api/src/deprecated.rs
@@ -21,7 +21,7 @@ pub fn exec(src: &str, output: bool) -> Result<Option<String>> {
     let src = types::String::from(src);
     let mut err = types::Error::new();
     let output = unsafe {
-        nvim_exec(LUA_INTERNAL_CALL, src.non_owning(), output, &mut err)
+        nvim_exec(LUA_INTERNAL_CALL, src.as_nvim_str(), output, &mut err)
     };
     choose!(err, {
         Ok((!output.is_empty()).then(|| output.to_string_lossy().into()))
@@ -63,7 +63,7 @@ pub fn get_hl_by_name(name: &str, rgb: bool) -> Result<HighlightInfos> {
     let mut err = types::Error::new();
     let hl = unsafe {
         nvim_get_hl_by_name(
-            name.non_owning(),
+            name.as_nvim_str(),
             rgb,
             core::ptr::null_mut(),
             &mut err,
@@ -89,7 +89,7 @@ where
     let mut err = types::Error::new();
     let obj = unsafe {
         nvim_get_option(
-            name.non_owning(),
+            name.as_nvim_str(),
             #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
             types::arena(),
             &mut err,
@@ -112,7 +112,7 @@ pub fn get_option_info(name: &str) -> Result<OptionInfos> {
     let mut err = types::Error::new();
     let obj = unsafe {
         nvim_get_option_info(
-            name.non_owning(),
+            name.as_nvim_str(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
             &mut err,
@@ -139,7 +139,7 @@ where
     unsafe {
         nvim_set_option(
             LUA_INTERNAL_CALL,
-            name.non_owning(),
+            name.as_nvim_str(),
             value.to_object()?.non_owning(),
             &mut err,
         )
@@ -166,7 +166,7 @@ impl Buffer {
         let obj = unsafe {
             nvim_buf_get_option(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
                 types::arena(),
                 &mut err,
@@ -195,7 +195,7 @@ impl Buffer {
             nvim_buf_set_option(
                 LUA_INTERNAL_CALL,
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 value.to_object()?.non_owning(),
                 &mut err,
             )
@@ -223,7 +223,7 @@ impl Window {
         let obj = unsafe {
             nvim_win_get_option(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
                 types::arena(),
                 &mut err,
@@ -252,7 +252,7 @@ impl Window {
             nvim_win_set_option(
                 LUA_INTERNAL_CALL,
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 value.to_object()?.non_owning(),
                 &mut err,
             )

--- a/crates/api/src/extmark.rs
+++ b/crates/api/src/extmark.rs
@@ -19,7 +19,7 @@ use crate::{Error, Result};
 /// [1]: https://neovim.io/doc/user/api.html#nvim_create_namespace()
 pub fn create_namespace(name: &str) -> u32 {
     let name = nvim::String::from(name);
-    unsafe { nvim_create_namespace(name.non_owning()) }
+    unsafe { nvim_create_namespace(name.as_nvim_str()) }
         .try_into()
         .expect("always positive")
 }
@@ -83,7 +83,7 @@ impl Buffer {
             nvim_buf_add_highlight(
                 self.0,
                 ns_id.into(),
-                hl_group.non_owning(),
+                hl_group.as_nvim_str(),
                 line as Integer,
                 start,
                 end,

--- a/crates/api/src/ffi/autocmd.rs
+++ b/crates/api/src/ffi/autocmd.rs
@@ -18,7 +18,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/autocmd.c#L629
     pub(crate) fn nvim_create_augroup(
         channel_id: u64,
-        name: NonOwning<String>,
+        name: NvimStr,
         opts: *const CreateAugroupOpts,
         err: *mut Error,
     ) -> Integer;
@@ -37,10 +37,7 @@ extern "C" {
     pub(crate) fn nvim_del_augroup_by_id(id: Integer, err: *mut Error);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/autocmd.c#L678
-    pub(crate) fn nvim_del_augroup_by_name(
-        name: NonOwning<String>,
-        err: *mut Error,
-    );
+    pub(crate) fn nvim_del_augroup_by_name(name: NvimStr, err: *mut Error);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/autocmd.c#L523
     pub(crate) fn nvim_del_autocmd(id: Integer, err: *mut Error);

--- a/crates/api/src/ffi/buffer.rs
+++ b/crates/api/src/ffi/buffer.rs
@@ -30,22 +30,22 @@ extern "C" {
     pub(crate) fn nvim_buf_del_keymap(
         channel_id: u64,
         buf: BufHandle,
-        mode: NonOwning<String>,
-        lhs: NonOwning<String>,
+        mode: NvimStr,
+        lhs: NvimStr,
         err: *mut Error,
     );
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L1071
     pub(crate) fn nvim_buf_del_mark(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         err: *mut Error,
     ) -> bool;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L928
     pub(crate) fn nvim_buf_del_var(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         err: *mut Error,
     );
 
@@ -68,7 +68,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.8.3/src/nvim/api/buffer.c#L869
     pub(crate) fn nvim_buf_get_keymap(
         buf: BufHandle,
-        mode: NonOwning<String>,
+        mode: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -90,7 +90,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L1149
     pub(crate) fn nvim_buf_get_mark(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -131,7 +131,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L832
     pub(crate) fn nvim_buf_get_var(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -153,9 +153,9 @@ extern "C" {
     pub(crate) fn nvim_buf_set_keymap(
         channel_id: u64,
         buf: BufHandle,
-        mode: NonOwning<String>,
-        lhs: NonOwning<String>,
-        rhs: NonOwning<String>,
+        mode: NvimStr,
+        lhs: NvimStr,
+        rhs: NvimStr,
         opts: *const SetKeymapOpts,
         err: *mut Error,
     );
@@ -176,7 +176,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L1116
     pub(crate) fn nvim_buf_set_mark(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         line: Integer,
         col: Integer,
         #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
@@ -189,7 +189,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L963
     pub(crate) fn nvim_buf_set_name(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         err: *mut Error,
     );
 
@@ -210,7 +210,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L911
     pub(crate) fn nvim_buf_set_var(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );

--- a/crates/api/src/ffi/command.rs
+++ b/crates/api/src/ffi/command.rs
@@ -17,7 +17,7 @@ extern "C" {
     pub(crate) fn nvim_buf_create_user_command(
         channel_id: u64,
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         command: NonOwning<Object>,
         opts: *const CreateCommandOpts,
         err: *mut Error,
@@ -26,7 +26,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/buffer.c#L925
     pub(crate) fn nvim_buf_del_user_command(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         err: *mut Error,
     );
 
@@ -52,17 +52,14 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/command.c#L880
     pub(crate) fn nvim_create_user_command(
         channel_id: u64,
-        name: NonOwning<String>,
+        name: NvimStr,
         command: NonOwning<Object>,
         opts: *const CreateCommandOpts,
         err: *mut Error,
     );
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/command.c#L891
-    pub(crate) fn nvim_del_user_command(
-        name: NonOwning<String>,
-        err: *mut Error,
-    );
+    pub(crate) fn nvim_del_user_command(name: NvimStr, err: *mut Error);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/command.c#L1169
     pub(crate) fn nvim_get_commands(
@@ -74,7 +71,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/command.c#L99
     pub(crate) fn nvim_parse_cmd(
-        src: NonOwning<String>,
+        src: NvimStr,
         #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
         opts: NonOwning<Dictionary>,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.

--- a/crates/api/src/ffi/deprecated.rs
+++ b/crates/api/src/ffi/deprecated.rs
@@ -8,7 +8,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/deprecated.c#L559
     pub(crate) fn nvim_buf_get_option(
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
         arena: *mut Arena,
         err: *mut Error,
@@ -18,7 +18,7 @@ extern "C" {
     pub(crate) fn nvim_buf_set_option(
         channel_id: u64,
         buf: BufHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );
@@ -26,7 +26,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/deprecated.c#L37
     pub(crate) fn nvim_exec(
         channel_id: u64,
-        src: NonOwning<String>,
+        src: NvimStr,
         output: Boolean,
         error: *mut Error,
     ) -> String;
@@ -41,7 +41,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/deprecated.c#L207
     pub(crate) fn nvim_get_hl_by_name(
-        name: NonOwning<String>,
+        name: NvimStr,
         rgb: bool,
         arena: *mut core::ffi::c_void,
         error: *mut Error,
@@ -49,7 +49,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/deprecated.c#L545
     pub(crate) fn nvim_get_option(
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
         arena: *mut Arena,
         err: *mut Error,
@@ -57,7 +57,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/deprecated.c#L518
     pub(crate) fn nvim_get_option_info(
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly
         arena: *mut Arena,
         err: *mut Error,
@@ -66,7 +66,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/deprecated.c#L532
     pub(crate) fn nvim_set_option(
         channel_id: u64,
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );
@@ -74,7 +74,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/deprecated.c#L601
     pub(crate) fn nvim_win_get_option(
         win: WinHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
         arena: *mut Arena,
         err: *mut Error,
@@ -84,7 +84,7 @@ extern "C" {
     pub(crate) fn nvim_win_set_option(
         channel_id: u64,
         win: WinHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );

--- a/crates/api/src/ffi/extmark.rs
+++ b/crates/api/src/ffi/extmark.rs
@@ -11,7 +11,7 @@ extern "C" {
     pub(crate) fn nvim_buf_add_highlight(
         buf: BufHandle,
         ns_id: Integer,
-        hl_group: NonOwning<String>,
+        hl_group: NvimStr,
         line: Integer,
         col_start: Integer,
         col_end: Integer,
@@ -75,7 +75,7 @@ extern "C" {
     ) -> Integer;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/extmark.c#L57
-    pub(crate) fn nvim_create_namespace(name: NonOwning<String>) -> Integer;
+    pub(crate) fn nvim_create_namespace(name: NvimStr) -> Integer;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/extmark.c#L75
     pub(crate) fn nvim_get_namespaces(

--- a/crates/api/src/ffi/options.rs
+++ b/crates/api/src/ffi/options.rs
@@ -17,7 +17,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/master/src/nvim/api/options.c#L305
     #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
     pub(crate) fn nvim_get_option_info2(
-        name: NonOwning<String>,
+        name: NvimStr,
         opts: *const OptionOpts,
         arena: *mut Arena,
         err: *mut Error,
@@ -25,7 +25,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/options.c#L152
     pub(crate) fn nvim_get_option_value(
-        name: NonOwning<String>,
+        name: NvimStr,
         opts: *const OptionOpts,
         err: *mut Error,
     ) -> Object;
@@ -33,7 +33,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/options.c#L217
     pub(crate) fn nvim_set_option_value(
         channel_id: u64,
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         opts: *const OptionOpts,
         err: *mut Error,

--- a/crates/api/src/ffi/tabpage.rs
+++ b/crates/api/src/ffi/tabpage.rs
@@ -8,7 +8,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/tabpage.c#L87
     pub(crate) fn nvim_tabpage_del_var(
         tabpage: TabHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         err: *mut Error,
     );
 
@@ -21,7 +21,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/tabpage.c#L52
     pub(crate) fn nvim_tabpage_get_var(
         tabpage: TabHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -47,7 +47,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/tabpage.c#L70
     pub(crate) fn nvim_tabpage_set_var(
         tabpage: TabHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );

--- a/crates/api/src/ffi/vim.rs
+++ b/crates/api/src/ffi/vim.rs
@@ -10,7 +10,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1146
     pub(crate) fn nvim_chan_send(
         chan: Integer,
-        data: NonOwning<String>,
+        data: NvimStr,
         err: *mut Error,
     );
 
@@ -31,19 +31,16 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1549
     pub(crate) fn nvim_del_keymap(
         channel_id: u64,
-        mode: NonOwning<String>,
-        lhs: NonOwning<String>,
+        mode: NvimStr,
+        lhs: NvimStr,
         err: *mut Error,
     );
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L2000
-    pub(crate) fn nvim_del_mark(
-        name: NonOwning<String>,
-        err: *mut Error,
-    ) -> bool;
+    pub(crate) fn nvim_del_mark(name: NvimStr, err: *mut Error) -> bool;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L746
-    pub(crate) fn nvim_del_var(name: NonOwning<String>, err: *mut Error);
+    pub(crate) fn nvim_del_var(name: NvimStr, err: *mut Error);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L784
     pub(crate) fn nvim_echo(
@@ -54,14 +51,14 @@ extern "C" {
     );
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L826
-    pub(crate) fn nvim_err_write(str: NonOwning<String>);
+    pub(crate) fn nvim_err_write(str: NvimStr);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L837
-    pub(crate) fn nvim_err_writeln(str: NonOwning<String>);
+    pub(crate) fn nvim_err_writeln(str: NvimStr);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L2114
     pub(crate) fn nvim_eval_statusline(
-        str: NonOwning<String>,
+        str: NvimStr,
         opts: *const EvalStatuslineOpts,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
@@ -69,11 +66,7 @@ extern "C" {
     ) -> Dictionary;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L274
-    pub(crate) fn nvim_feedkeys(
-        keys: NonOwning<String>,
-        mode: NonOwning<String>,
-        escape_ks: bool,
-    );
+    pub(crate) fn nvim_feedkeys(keys: NvimStr, mode: NvimStr, escape_ks: bool);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1679
     pub(crate) fn nvim_get_chan_info(
@@ -82,7 +75,7 @@ extern "C" {
     ) -> Dictionary;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1275
-    pub(crate) fn nvim_get_color_by_name(name: NonOwning<String>) -> Integer;
+    pub(crate) fn nvim_get_color_by_name(name: NvimStr) -> Integer;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1392
     pub(crate) fn nvim_get_color_map(
@@ -124,7 +117,7 @@ extern "C" {
     ) -> Dictionary;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L96
-    pub(crate) fn nvim_get_hl_id_by_name(name: NonOwning<String>) -> Integer;
+    pub(crate) fn nvim_get_hl_id_by_name(name: NvimStr) -> Integer;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L204
     #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
@@ -135,14 +128,14 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.8.3/src/nvim/api/vim.c#L1497
     pub(crate) fn nvim_get_keymap(
-        mode: NonOwning<String>,
+        mode: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
     ) -> Array;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1999
     pub(crate) fn nvim_get_mark(
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
         opts: NonOwning<Dictionary>,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
@@ -176,7 +169,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L586
     pub(crate) fn nvim_get_runtime_file(
-        name: NonOwning<String>,
+        name: NvimStr,
         all: bool,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
@@ -185,7 +178,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L714
     pub(crate) fn nvim_get_var(
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -193,7 +186,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L757
     pub(crate) fn nvim_get_vvar(
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -202,14 +195,14 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L360
     pub(crate) fn nvim_input(
         #[cfg(feature = "neovim-nightly")] channel_id: u64,
-        keys: NonOwning<String>,
+        keys: NvimStr,
     ) -> Integer;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L390
     pub(crate) fn nvim_input_mouse(
-        button: NonOwning<String>,
-        action: NonOwning<String>,
-        modifier: NonOwning<String>,
+        button: NvimStr,
+        action: NvimStr,
+        modifier: NvimStr,
         grid: Integer,
         row: Integer,
         col: Integer,
@@ -252,7 +245,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L527
     pub(crate) fn nvim_notify(
-        msg: NonOwning<String>,
+        msg: NvimStr,
         log_level: Integer,
         opts: NonOwning<Dictionary>,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and Nightly.
@@ -271,11 +264,11 @@ extern "C" {
     ) -> Integer;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L816
-    pub(crate) fn nvim_out_write(str: NonOwning<String>);
+    pub(crate) fn nvim_out_write(str: NvimStr);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1235
     pub(crate) fn nvim_paste(
-        data: NonOwning<String>,
+        data: NvimStr,
         crlf: bool,
         phase: Integer,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
@@ -286,7 +279,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1302
     pub(crate) fn nvim_put(
         lines: NonOwning<Array>,
-        r#type: NonOwning<String>,
+        r#type: NvimStr,
         after: bool,
         follow: bool,
         err: *mut Error,
@@ -294,7 +287,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L474
     pub(crate) fn nvim_replace_termcodes(
-        str: NonOwning<String>,
+        str: NvimStr,
         from_part: bool,
         do_lt: bool,
         special: bool,
@@ -316,14 +309,11 @@ extern "C" {
     pub(crate) fn nvim_set_current_buf(buffer: BufHandle, err: *mut Error);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L655
-    pub(crate) fn nvim_set_current_dir(
-        dir: NonOwning<String>,
-        err: *mut Error,
-    );
+    pub(crate) fn nvim_set_current_dir(dir: NvimStr, err: *mut Error);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L692
     pub(crate) fn nvim_set_current_line(
-        line: NonOwning<String>,
+        line: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -343,7 +333,7 @@ extern "C" {
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         channel_id: u64,
         ns_id: Integer,
-        name: NonOwning<String>,
+        name: NvimStr,
         val: *const SetHighlightOpts,
         err: *mut Error,
     );
@@ -359,30 +349,27 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L1537
     pub(crate) fn nvim_set_keymap(
         channel_id: u64,
-        mode: NonOwning<String>,
-        lhs: NonOwning<String>,
-        rhs: NonOwning<String>,
+        mode: NvimStr,
+        lhs: NvimStr,
+        rhs: NvimStr,
         opts: *const SetKeymapOpts,
         err: *mut Error,
     );
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L736
     pub(crate) fn nvim_set_var(
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L768
     pub(crate) fn nvim_set_vvar(
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vim.c#L544
-    pub(crate) fn nvim_strwidth(
-        text: NonOwning<String>,
-        err: *mut Error,
-    ) -> Integer;
+    pub(crate) fn nvim_strwidth(text: NvimStr, err: *mut Error) -> Integer;
 }

--- a/crates/api/src/ffi/vimscript.rs
+++ b/crates/api/src/ffi/vimscript.rs
@@ -8,7 +8,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vimscript.c#L278
     pub(crate) fn nvim_call_dict_function(
         dict: NonOwning<Object>,
-        r#fn: NonOwning<String>,
+        r#fn: NvimStr,
         args: NonOwning<Array>,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
@@ -17,7 +17,7 @@ extern "C" {
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vimscript.c#L263
     pub(crate) fn nvim_call_function(
-        r#fn: NonOwning<String>,
+        r#fn: NvimStr,
         args: NonOwning<Array>,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
@@ -25,11 +25,11 @@ extern "C" {
     ) -> Object;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vimscript.c#L135
-    pub(crate) fn nvim_command(command: NonOwning<String>, err: *mut Error);
+    pub(crate) fn nvim_command(command: NvimStr, err: *mut Error);
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vimscript.c#L151
     pub(crate) fn nvim_eval(
-        expr: NonOwning<String>,
+        expr: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -39,15 +39,15 @@ extern "C" {
     #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
     pub(crate) fn nvim_exec2(
         channel_id: u64,
-        src: NonOwning<String>,
+        src: NvimStr,
         opts: *const crate::opts::ExecOpts,
         error: *mut Error,
     ) -> Dictionary;
 
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/vimscript.c#L430
     pub fn nvim_parse_expression(
-        expr: NonOwning<String>,
-        flags: NonOwning<String>,
+        expr: NvimStr,
+        flags: NvimStr,
         highlight: bool,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,

--- a/crates/api/src/ffi/window.rs
+++ b/crates/api/src/ffi/window.rs
@@ -22,7 +22,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/window.c#L268
     pub(crate) fn nvim_win_del_var(
         win: WinHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         err: *mut Error,
     );
 
@@ -69,7 +69,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/window.c#L233
     pub(crate) fn nvim_win_get_var(
         win: WinHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
         arena: *mut Arena,
         err: *mut Error,
@@ -119,7 +119,7 @@ extern "C" {
     // https://github.com/neovim/neovim/blob/v0.10.0/src/nvim/api/window.c#L251
     pub(crate) fn nvim_win_set_var(
         win: WinHandle,
-        name: NonOwning<String>,
+        name: NvimStr,
         value: NonOwning<Object>,
         err: *mut Error,
     );

--- a/crates/api/src/options.rs
+++ b/crates/api/src/options.rs
@@ -50,7 +50,7 @@ pub fn get_option_info2(name: &str, opts: &OptionOpts) -> Result<OptionInfos> {
     let mut err = types::Error::new();
     let dict = unsafe {
         nvim_get_option_info2(
-            name.non_owning(),
+            name.as_nvim_str(),
             opts,
             types::arena(),
             &mut err,
@@ -76,7 +76,7 @@ where
     let name = nvim::String::from(name);
     let mut err = nvim::Error::new();
     let obj =
-        unsafe { nvim_get_option_value(name.non_owning(), opts, &mut err) };
+        unsafe { nvim_get_option_value(name.as_nvim_str(), opts, &mut err) };
     choose!(err, Ok(Opt::from_object(obj)?))
 }
 
@@ -101,7 +101,7 @@ where
     unsafe {
         nvim_set_option_value(
             crate::LUA_INTERNAL_CALL,
-            name.non_owning(),
+            name.as_nvim_str(),
             value.to_object()?.non_owning(),
             opts,
             &mut err,

--- a/crates/api/src/tabpage.rs
+++ b/crates/api/src/tabpage.rs
@@ -88,7 +88,7 @@ impl TabPage {
     pub fn del_var(&mut self, name: &str) -> Result<()> {
         let mut err = nvim::Error::new();
         let name = nvim::String::from(name);
-        unsafe { nvim_tabpage_del_var(self.0, name.non_owning(), &mut err) };
+        unsafe { nvim_tabpage_del_var(self.0, name.as_nvim_str(), &mut err) };
         choose!(err, ())
     }
 
@@ -117,7 +117,7 @@ impl TabPage {
         let obj = unsafe {
             nvim_tabpage_get_var(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
                 types::arena(),
                 &mut err,
@@ -183,7 +183,7 @@ impl TabPage {
         unsafe {
             nvim_tabpage_set_var(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 value.to_object()?.non_owning(),
                 &mut err,
             )

--- a/crates/api/src/vim.rs
+++ b/crates/api/src/vim.rs
@@ -26,7 +26,7 @@ use crate::{Error, Result};
 pub fn chan_send(channel_id: u32, data: &str) -> Result<()> {
     let mut err = nvim::Error::new();
     let data = nvim::String::from(data);
-    unsafe { nvim_chan_send(channel_id.into(), data.non_owning(), &mut err) };
+    unsafe { nvim_chan_send(channel_id.into(), data.as_nvim_str(), &mut err) };
     choose!(err, ())
 }
 
@@ -71,8 +71,8 @@ pub fn del_keymap(mode: Mode, lhs: &str) -> Result<()> {
     unsafe {
         nvim_del_keymap(
             LUA_INTERNAL_CALL,
-            mode.non_owning(),
-            lhs.non_owning(),
+            mode.as_nvim_str(),
+            lhs.as_nvim_str(),
             &mut err,
         )
     };
@@ -89,7 +89,7 @@ pub fn del_keymap(mode: Mode, lhs: &str) -> Result<()> {
 pub fn del_mark(name: char) -> Result<()> {
     let name = nvim::String::from(name);
     let mut err = nvim::Error::new();
-    let was_deleted = unsafe { nvim_del_mark(name.non_owning(), &mut err) };
+    let was_deleted = unsafe { nvim_del_mark(name.as_nvim_str(), &mut err) };
     choose!(
         err,
         match was_deleted {
@@ -107,7 +107,7 @@ pub fn del_mark(name: char) -> Result<()> {
 pub fn del_var(name: &str) -> Result<()> {
     let name = nvim::String::from(name);
     let mut err = nvim::Error::new();
-    unsafe { nvim_del_var(name.non_owning(), &mut err) };
+    unsafe { nvim_del_var(name.as_nvim_str(), &mut err) };
     choose!(err, ())
 }
 
@@ -149,7 +149,7 @@ where
 ///
 /// [1]: https://neovim.io/doc/user/api.html#nvim_err_write()
 pub fn err_write(str: &str) {
-    unsafe { nvim_err_write(nvim::String::from(str).non_owning()) }
+    unsafe { nvim_err_write(nvim::String::from(str).as_nvim_str()) }
 }
 
 /// Binding to [`nvim_err_writeln()`][1].
@@ -159,7 +159,7 @@ pub fn err_write(str: &str) {
 ///
 /// [1]: https://neovim.io/doc/user/api.html#nvim_err_writeln()
 pub fn err_writeln(str: &str) {
-    unsafe { nvim_err_writeln(nvim::String::from(str).non_owning()) }
+    unsafe { nvim_err_writeln(nvim::String::from(str).as_nvim_str()) }
 }
 
 /// Binding to [`nvim_eval_statusline()`][1].
@@ -175,7 +175,7 @@ pub fn eval_statusline(
     let mut err = nvim::Error::new();
     let dict = unsafe {
         nvim_eval_statusline(
-            str.non_owning(),
+            str.as_nvim_str(),
             opts,
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
@@ -191,7 +191,7 @@ pub fn eval_statusline(
 pub fn feedkeys(keys: &str, mode: Mode, escape_ks: bool) {
     let keys = nvim::String::from(keys);
     let mode = nvim::String::from(mode);
-    unsafe { nvim_feedkeys(keys.non_owning(), mode.non_owning(), escape_ks) }
+    unsafe { nvim_feedkeys(keys.as_nvim_str(), mode.as_nvim_str(), escape_ks) }
 }
 
 /// Binding to [`nvim_get_chan_info()`][1].
@@ -213,7 +213,7 @@ pub fn get_chan_info(channel_id: u32) -> Result<ChannelInfos> {
 /// [1]: https://neovim.io/doc/user/api.html#nvim_get_color_by_name()
 pub fn get_color_by_name(name: &str) -> Result<u32> {
     let name = nvim::String::from(name);
-    let color = unsafe { nvim_get_color_by_name(name.non_owning()) };
+    let color = unsafe { nvim_get_color_by_name(name.as_nvim_str()) };
     (color != -1).then(|| color.try_into().unwrap()).ok_or_else(|| {
         Error::custom(format!("{name:?} is not a valid color name"))
     })
@@ -349,7 +349,7 @@ pub fn get_hl(
 /// [1]: https://neovim.io/doc/user/api.html#nvim_get_hl_id_by_name()
 pub fn get_hl_id_by_name(name: &str) -> Result<u32> {
     let name = nvim::String::from(name);
-    let id = unsafe { nvim_get_hl_id_by_name(name.non_owning()) };
+    let id = unsafe { nvim_get_hl_id_by_name(name.as_nvim_str()) };
     id.try_into().map_err(Into::into)
 }
 
@@ -378,7 +378,7 @@ pub fn get_keymap(mode: Mode) -> impl SuperIterator<KeymapInfos> {
     let mode = nvim::String::from(mode);
     let keymaps = unsafe {
         nvim_get_keymap(
-            mode.non_owning(),
+            mode.as_nvim_str(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
         )
@@ -402,7 +402,7 @@ pub fn get_mark(
     let mut err = nvim::Error::new();
     let mark = unsafe {
         nvim_get_mark(
-            name.non_owning(),
+            name.as_nvim_str(),
             #[cfg(not(feature = "neovim-0-10"))] // 0nly on 0.9.
             opts.non_owning(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
@@ -494,7 +494,7 @@ pub fn get_runtime_file(
     let mut err = nvim::Error::new();
     let files = unsafe {
         nvim_get_runtime_file(
-            name.non_owning(),
+            name.as_nvim_str(),
             get_all,
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
@@ -524,7 +524,7 @@ where
     let name = nvim::String::from(name);
     let obj = unsafe {
         nvim_get_var(
-            name.non_owning(),
+            name.as_nvim_str(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
             &mut err,
@@ -546,7 +546,7 @@ where
     let mut err = nvim::Error::new();
     let obj = unsafe {
         nvim_get_vvar(
-            name.non_owning(),
+            name.as_nvim_str(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
             &mut err,
@@ -571,7 +571,7 @@ where
         nvim_input(
             #[cfg(feature = "neovim-nightly")]
             LUA_INTERNAL_CALL,
-            keys.into().non_owning(),
+            keys.into().as_nvim_str(),
         )
     }
     .try_into()
@@ -597,9 +597,9 @@ pub fn input_mouse(
     let mut err = nvim::Error::new();
     unsafe {
         nvim_input_mouse(
-            button.non_owning(),
-            action.non_owning(),
-            modifier.non_owning(),
+            button.as_nvim_str(),
+            action.as_nvim_str(),
+            modifier.as_nvim_str(),
             grid.into(),
             row.try_into()?,
             col.try_into()?,
@@ -727,7 +727,7 @@ pub fn notify(
     let mut err = nvim::Error::new();
     let obj = unsafe {
         nvim_notify(
-            msg.non_owning(),
+            msg.as_nvim_str(),
             log_level as Integer,
             opts.non_owning(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
@@ -778,7 +778,7 @@ pub fn out_write<Msg>(str: Msg)
 where
     Msg: Into<nvim::String>,
 {
-    unsafe { nvim_out_write(str.into().non_owning()) }
+    unsafe { nvim_out_write(str.into().as_nvim_str()) }
 }
 
 /// Binding to [`nvim_paste()`][1].
@@ -794,7 +794,7 @@ where
     let mut err = nvim::Error::new();
     let go_on = unsafe {
         nvim_paste(
-            data.into().non_owning(),
+            data.into().as_nvim_str(),
             crlf,
             phase as Integer,
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
@@ -826,7 +826,7 @@ where
     unsafe {
         nvim_put(
             lines.non_owning(),
-            reg_type.non_owning(),
+            reg_type.as_nvim_str(),
             after,
             follow,
             &mut err,
@@ -852,7 +852,7 @@ where
 {
     let str = str.into();
     unsafe {
-        nvim_replace_termcodes(str.non_owning(), from_part, do_lt, special)
+        nvim_replace_termcodes(str.as_nvim_str(), from_part, do_lt, special)
     }
 }
 
@@ -907,7 +907,7 @@ where
 {
     let dir = nvim::String::from(dir.as_ref());
     let mut err = nvim::Error::new();
-    unsafe { nvim_set_current_dir(dir.non_owning(), &mut err) };
+    unsafe { nvim_set_current_dir(dir.as_nvim_str(), &mut err) };
     choose!(err, ())
 }
 
@@ -923,7 +923,7 @@ where
     let mut err = nvim::Error::new();
     unsafe {
         nvim_set_current_line(
-            line.into().non_owning(),
+            line.into().as_nvim_str(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
             &mut err,
@@ -967,7 +967,7 @@ pub fn set_hl(ns_id: u32, name: &str, opts: &SetHighlightOpts) -> Result<()> {
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             LUA_INTERNAL_CALL,
             ns_id as Integer,
-            name.non_owning(),
+            name.as_nvim_str(),
             opts,
             &mut err,
         )
@@ -1033,9 +1033,9 @@ pub fn set_keymap(
     unsafe {
         nvim_set_keymap(
             LUA_INTERNAL_CALL,
-            mode.non_owning(),
-            lhs.non_owning(),
-            rhs.non_owning(),
+            mode.as_nvim_str(),
+            lhs.as_nvim_str(),
+            rhs.as_nvim_str(),
             opts,
             &mut err,
         )
@@ -1055,7 +1055,7 @@ where
     let name = nvim::String::from(name);
     let value = value.to_object()?;
     let mut err = nvim::Error::new();
-    unsafe { nvim_set_var(name.non_owning(), value.non_owning(), &mut err) };
+    unsafe { nvim_set_var(name.as_nvim_str(), value.non_owning(), &mut err) };
     choose!(err, ())
 }
 
@@ -1071,7 +1071,7 @@ where
     let name = nvim::String::from(name);
     let value = value.to_object()?;
     let mut err = nvim::Error::new();
-    unsafe { nvim_set_vvar(name.non_owning(), value.non_owning(), &mut err) };
+    unsafe { nvim_set_vvar(name.as_nvim_str(), value.non_owning(), &mut err) };
     choose!(err, ())
 }
 
@@ -1084,6 +1084,6 @@ where
 pub fn strwidth(text: &str) -> Result<usize> {
     let text = nvim::String::from(text);
     let mut err = nvim::Error::new();
-    let width = unsafe { nvim_strwidth(text.non_owning(), &mut err) };
+    let width = unsafe { nvim_strwidth(text.as_nvim_str(), &mut err) };
     choose!(err, Ok(width.try_into().expect("always positive")))
 }

--- a/crates/api/src/vimscript.rs
+++ b/crates/api/src/vimscript.rs
@@ -29,7 +29,7 @@ where
     let res = unsafe {
         nvim_call_dict_function(
             dict.non_owning(),
-            func.non_owning(),
+            func.as_nvim_str(),
             args.non_owning(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
@@ -55,7 +55,7 @@ where
     let mut err = nvim::Error::new();
     let res = unsafe {
         nvim_call_function(
-            func.non_owning(),
+            func.as_nvim_str(),
             args.non_owning(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
@@ -73,7 +73,7 @@ where
 pub fn command(command: &str) -> Result<()> {
     let command = nvim::String::from(command);
     let mut err = nvim::Error::new();
-    unsafe { nvim_command(command.non_owning(), &mut err) };
+    unsafe { nvim_command(command.as_nvim_str(), &mut err) };
     choose!(err, ())
 }
 
@@ -90,7 +90,7 @@ where
     let mut err = nvim::Error::new();
     let output = unsafe {
         nvim_eval(
-            expr.non_owning(),
+            expr.as_nvim_str(),
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),
             &mut err,
@@ -116,7 +116,7 @@ pub fn exec2(src: &str, opts: &ExecOpts) -> Result<Option<nvim::String>> {
     let src = types::String::from(src);
     let mut err = types::Error::new();
     let dict = unsafe {
-        nvim_exec2(crate::LUA_INTERNAL_CALL, src.non_owning(), opts, &mut err)
+        nvim_exec2(crate::LUA_INTERNAL_CALL, src.as_nvim_str(), opts, &mut err)
     };
     choose!(err, {
         Ok(dict
@@ -141,8 +141,8 @@ pub fn parse_expression(
     let mut err = nvim::Error::new();
     let dict = unsafe {
         nvim_parse_expression(
-            expr.non_owning(),
-            flags.non_owning(),
+            expr.as_nvim_str(),
+            flags.as_nvim_str(),
             include_highlight,
             #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
             types::arena(),

--- a/crates/api/src/window.rs
+++ b/crates/api/src/window.rs
@@ -165,7 +165,7 @@ impl Window {
     pub fn del_var(&mut self, name: &str) -> Result<()> {
         let mut err = nvim::Error::new();
         let name = nvim::String::from(name);
-        unsafe { nvim_win_del_var(self.0, name.non_owning(), &mut err) };
+        unsafe { nvim_win_del_var(self.0, name.as_nvim_str(), &mut err) };
         choose!(err, ())
     }
 
@@ -273,7 +273,7 @@ impl Window {
         let obj = unsafe {
             nvim_win_get_var(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 #[cfg(feature = "neovim-0-10")] // On 0.10 and nightly.
                 types::arena(),
                 &mut err,
@@ -382,7 +382,7 @@ impl Window {
         unsafe {
             nvim_win_set_var(
                 self.0,
-                name.non_owning(),
+                name.as_nvim_str(),
                 value.to_object()?.non_owning(),
                 &mut err,
             )

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -16,6 +16,7 @@ mod object;
 pub mod serde;
 mod str;
 mod string;
+mod string_builder;
 
 pub use arena::{arena, arena_init, Arena};
 pub use array::{Array, ArrayFromTupleError};
@@ -25,7 +26,8 @@ pub use function::Function;
 pub use non_owning::NonOwning;
 pub use object::{Object, ObjectKind};
 pub use str::NvimStr;
-pub use string::{String, StringBuilder};
+pub use string::String;
+pub use string_builder::StringBuilder;
 
 pub mod iter {
     //! Iterators over [`Array`](crate::Array)s and

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -14,6 +14,7 @@ mod non_owning;
 mod object;
 #[cfg(feature = "serde")]
 pub mod serde;
+mod str;
 mod string;
 
 pub use arena::{arena, arena_init, Arena};
@@ -23,6 +24,7 @@ pub use error::Error;
 pub use function::Function;
 pub use non_owning::NonOwning;
 pub use object::{Object, ObjectKind};
+pub use str::NvimStr;
 pub use string::{String, StringBuilder};
 
 pub mod iter {

--- a/crates/types/src/str.rs
+++ b/crates/types/src/str.rs
@@ -1,0 +1,53 @@
+use core::marker::PhantomData;
+use core::{ffi, slice};
+
+/// TODO: docs.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct NvimStr<'a> {
+    data: *mut ffi::c_char,
+    len: usize,
+    _lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> NvimStr<'a> {
+    /// Converts the [`NvimStr`] into a byte slice, *not* including the final
+    /// null byte.
+    ///
+    /// If you need a byte slice that includes the final null byte, use
+    /// [`as_bytes_with_nul`](Self::as_bytes_with_nul) instead.
+    #[inline]
+    pub const fn as_bytes(&self) -> &'a [u8] {
+        let bytes = self.as_bytes_with_nul();
+        unsafe { slice::from_raw_parts(bytes.as_ptr(), bytes.len() - 1) }
+    }
+
+    /// Converts the [`NvimStr`] into a byte slice, including the final
+    /// null byte.
+    ///
+    /// If you don't want the final null byte to be included in the slice, use
+    /// [`as_bytes`](Self::as_bytes) instead.
+    #[inline]
+    pub const fn as_bytes_with_nul(&self) -> &'a [u8] {
+        if self.data.is_null() {
+            &[]
+        } else {
+            unsafe {
+                slice::from_raw_parts(self.as_ptr() as *const u8, self.len + 1)
+            }
+        }
+    }
+
+    /// Returns a pointer to the [`NvimStr`]'s buffer.
+    #[inline]
+    pub const fn as_ptr(&self) -> *const ffi::c_char {
+        self.data
+    }
+
+    /// Returns the length of the [`NvimStr`], *not* including the final null
+    /// byte.
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+}

--- a/crates/types/src/str.rs
+++ b/crates/types/src/str.rs
@@ -22,8 +22,7 @@ impl<'a> NvimStr<'a> {
     /// [`as_bytes_with_nul`](Self::as_bytes_with_nul) instead.
     #[inline]
     pub const fn as_bytes(&self) -> &'a [u8] {
-        let bytes = self.as_bytes_with_nul();
-        unsafe { slice::from_raw_parts(bytes.as_ptr(), bytes.len() - 1) }
+        self.as_bytes_inner(false)
     }
 
     /// Converts the [`NvimStr`] into a byte slice, including the final
@@ -33,13 +32,7 @@ impl<'a> NvimStr<'a> {
     /// [`as_bytes`](Self::as_bytes) instead.
     #[inline]
     pub const fn as_bytes_with_nul(&self) -> &'a [u8] {
-        if self.data.is_null() {
-            &[]
-        } else {
-            unsafe {
-                slice::from_raw_parts(self.as_ptr() as *const u8, self.len + 1)
-            }
-        }
+        self.as_bytes_inner(false)
     }
 
     /// Returns a raw pointer to the [`NvimStr`]'s buffer.
@@ -111,6 +104,20 @@ impl<'a> NvimStr<'a> {
     #[inline]
     pub(crate) fn reborrow(&self) -> NvimStr<'_> {
         NvimStr { ..*self }
+    }
+
+    #[inline]
+    const fn as_bytes_inner(&self, with_nul: bool) -> &'a [u8] {
+        if self.data.is_null() {
+            &[]
+        } else {
+            unsafe {
+                slice::from_raw_parts(
+                    self.as_ptr() as *const u8,
+                    self.len + with_nul as usize,
+                )
+            }
+        }
     }
 }
 

--- a/crates/types/src/str.rs
+++ b/crates/types/src/str.rs
@@ -54,9 +54,21 @@ impl<'a> NvimStr<'a> {
 
     /// Creates an `NvimStr` from a pointer to the underlying data and a
     /// length.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the pointer is valid for `len + 1`
+    /// elements and that the last element is a null byte.
     #[inline]
     pub unsafe fn from_raw_parts(data: *mut ffi::c_char, len: usize) -> Self {
         Self { data, len, _lifetime: PhantomData }
+    }
+
+    /// Returns `true` if the [`NvimStr`] has a length of zero, not including
+    /// the final null byte.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Returns the length of the [`NvimStr`], *not* including the final null

--- a/crates/types/src/str.rs
+++ b/crates/types/src/str.rs
@@ -77,6 +77,18 @@ impl<'a> NvimStr<'a> {
     pub const fn len(&self) -> usize {
         self.len
     }
+
+    /// Returns the length of the [`NvimStr`], *not* including the final null
+    /// byte.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the bytes at `old_len..new_len` are
+    /// initialized.
+    #[inline]
+    pub const unsafe fn set_len(&mut self, new_len: usize) {
+        self.len = new_len;
+    }
 }
 
 impl From<NvimString> for NvimStr<'_> {

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -3,13 +3,13 @@
 use alloc::borrow::Cow;
 use alloc::string::String as StdString;
 use core::str::{self, Utf8Error};
-use core::{ffi, fmt, ptr, slice};
-use std::num::NonZeroUsize;
+use core::{ffi, ptr, slice};
 use std::path::{Path, PathBuf};
 
 use luajit as lua;
 
 use crate::NonOwning;
+use crate::StringBuilder;
 
 /// Binding to the string type used by Neovim.
 ///
@@ -22,14 +22,6 @@ use crate::NonOwning;
 pub struct String {
     pub(super) data: *mut ffi::c_char,
     pub(super) len: usize,
-}
-
-/// A builder that can be used to efficiently build a [`nvim_oxi::String`](String).
-pub struct StringBuilder {
-    /// The underlying string being constructed.
-    pub(super) inner: String,
-    /// Current capacity (i.e., allocated memory) of this builder in bytes.
-    pub(super) cap: usize,
 }
 
 impl Default for String {
@@ -50,20 +42,6 @@ impl core::fmt::Display for String {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.to_string_lossy().as_ref().fmt(f)
-    }
-}
-
-impl Default for StringBuilder {
-    #[inline]
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl fmt::Write for StringBuilder {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        self.push_bytes(s.as_bytes());
-        Ok(())
     }
 }
 
@@ -135,185 +113,6 @@ impl String {
     }
 }
 
-impl StringBuilder {
-    /// Create a new empty `StringBuilder`.
-    #[inline]
-    pub fn new() -> Self {
-        Self { inner: String::new(), cap: 0 }
-    }
-
-    /// Push new bytes to the builder.
-    ///
-    /// When only pushing bytes once, prefer [`String::from_bytes`] as this
-    /// method may allocate extra space in the buffer.
-    #[inline]
-    pub fn push_bytes(&mut self, bytes: &[u8]) {
-        let slice_len = bytes.len();
-        if slice_len == 0 {
-            return;
-        }
-
-        // Reallocate if pushing the bytes overflows the allocated memory.
-        self.reserve(bytes.len());
-        debug_assert!(self.inner.len < self.cap);
-
-        // Pushing the `bytes` is safe now.
-        let new_len = unsafe {
-            libc::memcpy(
-                self.inner.data.add(self.inner.len) as *mut ffi::c_void,
-                bytes.as_ptr() as *const ffi::c_void,
-                slice_len,
-            );
-
-            let new_len = self.inner.len + slice_len;
-
-            *self.inner.data.add(new_len) = 0;
-
-            new_len
-        };
-
-        self.inner.len = new_len;
-        debug_assert!(self.inner.len < self.cap);
-    }
-
-    /// Initialize [`StringBuilder`] with capacity.
-    pub fn with_capacity(cap: usize) -> Self {
-        // Neovim uses `xstrdup` to clone strings, which doesn't support null
-        // pointers.
-        //
-        // For more infos, see https://github.com/noib3/nvim-oxi/pull/211#issuecomment-2566960494
-        //
-        // if cap == 0 {
-        //     return Self::new();
-        // }
-        let real_cap = cap + 1;
-        let ptr = unsafe { libc::malloc(real_cap) };
-        if ptr.is_null() {
-            unable_to_alloc_memory();
-        }
-        Self {
-            inner: String { len: 0, data: ptr as *mut ffi::c_char },
-            cap: real_cap,
-        }
-    }
-
-    /// Reserve space for `additional` more bytes.
-    ///
-    /// Does not allocate if enough space is available.
-    pub fn reserve(&mut self, additional: usize) {
-        let Some(min_capacity) = self.min_capacity_for_additional(additional)
-        else {
-            return;
-        };
-        let new_capacity =
-            min_capacity.checked_next_power_of_two().unwrap_or(min_capacity);
-        self.realloc(new_capacity);
-    }
-
-    /// Reserve space for exactly `additional` more bytes.
-    ///
-    /// Does not allocate if enough space is available.
-    pub fn reserve_exact(&mut self, additional: usize) {
-        if let Some(new_capacity) =
-            self.min_capacity_for_additional(additional)
-        {
-            self.realloc(new_capacity);
-        }
-    }
-
-    /// Reallocate the string with the given capacity.
-    fn realloc(&mut self, new_capacity: NonZeroUsize) {
-        let ptr = unsafe {
-            libc::realloc(
-                self.inner.data as *mut ffi::c_void,
-                new_capacity.get(),
-            )
-        };
-        // `realloc` may return null if it is unable to allocate the requested
-        // memory.
-        if ptr.is_null() {
-            unable_to_alloc_memory();
-        }
-        self.inner.data = ptr as *mut ffi::c_char;
-        self.cap = new_capacity.get();
-    }
-
-    /// Finish building the [`String`]
-    #[inline]
-    pub fn finish(self) -> String {
-        let mut s = String { data: self.inner.data, len: self.inner.len() };
-
-        if s.data.is_null() {
-            debug_assert!(s.is_empty());
-            debug_assert_eq!(self.cap, 0);
-
-            // The pointer of `String` should never be null, and it must be
-            // terminated by a null byte.
-            if s.data.is_null() {
-                unsafe {
-                    let ptr = libc::malloc(1) as *mut ffi::c_char;
-                    if ptr.is_null() {
-                        unable_to_alloc_memory();
-                    }
-                    ptr.write(0);
-
-                    s.data = ptr;
-                }
-            }
-        } else {
-            debug_assert!(self.cap > self.inner.len());
-        }
-
-        // Prevent self's destructor from being called.
-        std::mem::forget(self);
-        s
-    }
-
-    /// Returns the remaining *usable* capacity, i.e. the remaining capacity
-    /// minus the space reserved for the null terminator.
-    #[inline(always)]
-    fn remaining_capacity(&self) -> usize {
-        if self.inner.data.is_null() {
-            debug_assert_eq!(self.inner.len(), 0);
-            return 0;
-        }
-        debug_assert!(
-            self.cap > 0,
-            "when data ptr is not null capacity must always be larger than 0"
-        );
-        debug_assert!(
-            self.cap > self.inner.len(),
-            "allocated capacity must always be bigger than length"
-        );
-        self.cap - self.inner.len() - 1
-    }
-
-    /// Returns the minimum capacity needed to allocate `additional` bytes, or
-    /// `None` if the current capacity is already large enough.
-    #[inline]
-    fn min_capacity_for_additional(
-        &self,
-        additional: usize,
-    ) -> Option<NonZeroUsize> {
-        let remaining = self.remaining_capacity();
-        if remaining >= additional {
-            return None;
-        }
-        if self.inner.data.is_null() {
-            debug_assert_eq!(self.cap, 0);
-            NonZeroUsize::new(additional + 1)
-        } else {
-            NonZeroUsize::new(self.cap + additional - remaining)
-        }
-    }
-}
-
-#[cold]
-#[inline(never)]
-fn unable_to_alloc_memory() {
-    panic!("unable to alloc memory with libc::realloc")
-}
-
 impl Clone for String {
     #[inline]
     fn clone(&self) -> Self {
@@ -328,14 +127,6 @@ impl Drop for String {
         //
         // TODO: we're leaking memory here if the pointer points to allocated
         // memory.
-    }
-}
-
-impl Drop for StringBuilder {
-    fn drop(&mut self) {
-        if !self.inner.data.is_null() {
-            unsafe { libc::free(self.inner.data as *mut ffi::c_void) }
-        }
     }
 }
 
@@ -546,65 +337,6 @@ mod tests {
     }
 
     #[test]
-    fn with_capacity() {
-        let s = StringBuilder::with_capacity(0);
-        assert!(!s.inner.data.is_null());
-        assert_eq!(s.cap, 1);
-        assert_eq!(s.inner.len(), 0);
-        s.finish();
-        let s = StringBuilder::with_capacity(1);
-        assert_eq!(s.cap, 2);
-        assert_eq!(s.inner.len(), 0);
-        s.finish();
-        let s = StringBuilder::with_capacity(5);
-        assert_eq!(s.cap, 6);
-        assert_eq!(s.inner.len(), 0);
-        s.finish();
-    }
-
-    #[test]
-    fn reserve() {
-        let mut sb = StringBuilder::new();
-        assert_eq!(sb.cap, 0);
-        sb.reserve(10);
-        assert_eq!(sb.cap, 16);
-
-        // Shouldn't change the pointer address as we have enough space.
-        sb.reserve(10);
-        assert_eq!(sb.cap, 16);
-        let ptr = sb.inner.data;
-        sb.push_bytes(b"Hello World!");
-        // We already allocated the space needed the push above shouldn't
-        // change the pointer.
-        assert_eq!(sb.inner.data, ptr);
-        sb.push_bytes(&[b'a'; 55]);
-        // We shouldn't check the pointer again as the block might be extended
-        // instead of being moved to a different address.
-        assert_eq!(unsafe { *sb.inner.data.add(sb.inner.len) }, 0);
-        assert_eq!(sb.cap, 128);
-    }
-
-    #[test]
-    fn reserve_exact() {
-        let mut sb = StringBuilder::new();
-        sb.reserve_exact(10);
-        assert_eq!(sb.cap, 11);
-        let ptr = sb.inner.data;
-        sb.push_bytes(b"hi");
-        assert_eq!(sb.inner.len(), 2);
-
-        // The space is already allocated, pushing bytes shouldn't change the
-        // ptr address.
-        assert_eq!(ptr, sb.inner.data);
-        sb.push_bytes(b"Hello World!");
-        assert_eq!(sb.cap, 16);
-        assert_eq!(sb.inner.len(), 14);
-        let ptr = sb.inner.data;
-        sb.push_bytes(b"c");
-        assert_eq!(sb.inner.data, ptr);
-    }
-
-    #[test]
     fn partial_eq() {
         let lhs = String::from("foo bar baz");
         let rhs = String::from("foo bar baz");
@@ -635,22 +367,5 @@ mod tests {
         let rhs = String::from(foo.as_str());
 
         assert_eq!(lhs, rhs);
-    }
-
-    #[test]
-    fn builder() {
-        let s = "foo bar";
-        let bytes = b"baz foo bar";
-
-        let mut sb = StringBuilder::new();
-        sb.push_bytes(s.as_bytes());
-        sb.push_bytes(bytes);
-
-        assert_eq!(sb.inner.len, s.len() + bytes.len());
-        assert_eq!(sb.cap, 32); // Allocation size
-        assert_eq!(unsafe { *sb.inner.data.add(sb.inner.len) }, 0); // Null termination
-
-        let nv_str = sb.finish();
-        assert_eq!(nv_str.len(), s.len() + bytes.len());
     }
 }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 
 use luajit as lua;
 
+use crate::NvimStr;
 use crate::StringBuilder;
-use crate::{NonOwning, NvimStr};
 
 /// Binding to the string type used by Neovim.
 ///
@@ -118,13 +118,6 @@ impl String {
     #[inline]
     pub fn new() -> Self {
         Self::from_bytes(&[])
-    }
-
-    /// Makes a non-owning version of this `String`.
-    #[inline]
-    #[doc(hidden)]
-    pub fn non_owning(&self) -> NonOwning<'_, String> {
-        NonOwning::new(Self { ..*self })
     }
 
     /// Forces the length of the string to be `new_len`.

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -85,6 +85,11 @@ impl String {
     }
 
     /// Creates a `String` from a pointer to the underlying data and a length.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the pointer is valid for `len + 1`
+    /// elements and that the last element is a null byte.
     #[inline]
     pub unsafe fn from_raw_parts(data: *mut ffi::c_char, len: usize) -> Self {
         Self { data, len }

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -128,6 +128,10 @@ impl String {
     }
 
     /// Forces the length of the string to be `new_len`.
+    ///
+    /// # Safety
+    ///
+    /// Same as [`NvimStr::set_len`].
     #[inline]
     pub unsafe fn set_len(&mut self, new_len: usize) {
         self.len = new_len;

--- a/crates/types/src/string_builder.rs
+++ b/crates/types/src/string_builder.rs
@@ -1,0 +1,297 @@
+use core::ffi;
+use core::fmt;
+use core::num::NonZeroUsize;
+
+use crate::String as NvimString;
+
+/// A builder that can be used to efficiently build
+/// [`nvim_oxi::String`](NvimString)s.
+pub struct StringBuilder {
+    /// The underlying string being constructed.
+    inner: NvimString,
+    /// Current capacity (i.e., allocated memory) of this builder in bytes.
+    cap: usize,
+}
+
+impl StringBuilder {
+    /// Create a new empty `StringBuilder`.
+    #[inline]
+    pub fn new() -> Self {
+        Self { inner: NvimString::new(), cap: 0 }
+    }
+
+    /// Push new bytes to the builder.
+    ///
+    /// When only pushing bytes once, prefer [`NvimString::from_bytes`] as this
+    /// method may allocate extra space in the buffer.
+    #[inline]
+    pub fn push_bytes(&mut self, bytes: &[u8]) {
+        let slice_len = bytes.len();
+        if slice_len == 0 {
+            return;
+        }
+
+        // Reallocate if pushing the bytes overflows the allocated memory.
+        self.reserve(bytes.len());
+        debug_assert!(self.inner.len() < self.cap);
+
+        // Pushing the `bytes` is safe now.
+        let new_len = unsafe {
+            libc::memcpy(
+                self.inner.as_ptr().add(self.inner.len()) as *mut ffi::c_void,
+                bytes.as_ptr() as *const ffi::c_void,
+                slice_len,
+            );
+
+            let new_len = self.inner.len() + slice_len;
+
+            *self.inner.data.add(new_len) = 0;
+
+            new_len
+        };
+
+        self.inner.len = new_len;
+        debug_assert!(self.inner.len() < self.cap);
+    }
+
+    /// Initialize [`StringBuilder`] with capacity.
+    pub fn with_capacity(cap: usize) -> Self {
+        // Neovim uses `xstrdup` to clone strings, which doesn't support null
+        // pointers.
+        //
+        // For more infos, see https://github.com/noib3/nvim-oxi/pull/211#issuecomment-2566960494
+        //
+        // if cap == 0 {
+        //     return Self::new();
+        // }
+        let real_cap = cap + 1;
+        let ptr = unsafe { libc::malloc(real_cap) };
+        if ptr.is_null() {
+            unable_to_alloc_memory();
+        }
+        Self {
+            inner: NvimString { len: 0, data: ptr as *mut ffi::c_char },
+            cap: real_cap,
+        }
+    }
+
+    /// Reserve space for `additional` more bytes.
+    ///
+    /// Does not allocate if enough space is available.
+    pub fn reserve(&mut self, additional: usize) {
+        let Some(min_capacity) = self.min_capacity_for_additional(additional)
+        else {
+            return;
+        };
+        let new_capacity =
+            min_capacity.checked_next_power_of_two().unwrap_or(min_capacity);
+        self.realloc(new_capacity);
+    }
+
+    /// Reserve space for exactly `additional` more bytes.
+    ///
+    /// Does not allocate if enough space is available.
+    pub fn reserve_exact(&mut self, additional: usize) {
+        if let Some(new_capacity) =
+            self.min_capacity_for_additional(additional)
+        {
+            self.realloc(new_capacity);
+        }
+    }
+
+    /// Reallocate the string with the given capacity.
+    fn realloc(&mut self, new_capacity: NonZeroUsize) {
+        let ptr = unsafe {
+            libc::realloc(
+                self.inner.data as *mut ffi::c_void,
+                new_capacity.get(),
+            )
+        };
+        // `realloc` may return null if it is unable to allocate the requested
+        // memory.
+        if ptr.is_null() {
+            unable_to_alloc_memory();
+        }
+        self.inner.data = ptr as *mut ffi::c_char;
+        self.cap = new_capacity.get();
+    }
+
+    /// Finish building the [`NvimString`]
+    #[inline]
+    pub fn finish(self) -> NvimString {
+        let mut s =
+            NvimString { data: self.inner.data, len: self.inner.len() };
+
+        if s.data.is_null() {
+            debug_assert!(s.is_empty());
+            debug_assert_eq!(self.cap, 0);
+
+            // The pointer of `NvimString` should never be null, and it must be
+            // terminated by a null byte.
+            if s.data.is_null() {
+                unsafe {
+                    let ptr = libc::malloc(1) as *mut ffi::c_char;
+                    if ptr.is_null() {
+                        unable_to_alloc_memory();
+                    }
+                    ptr.write(0);
+
+                    s.data = ptr;
+                }
+            }
+        } else {
+            debug_assert!(self.cap > self.inner.len());
+        }
+
+        // Prevent self's destructor from being called.
+        std::mem::forget(self);
+        s
+    }
+
+    /// Returns the remaining *usable* capacity, i.e. the remaining capacity
+    /// minus the space reserved for the null terminator.
+    #[inline(always)]
+    fn remaining_capacity(&self) -> usize {
+        if self.inner.data.is_null() {
+            debug_assert_eq!(self.inner.len(), 0);
+            return 0;
+        }
+        debug_assert!(
+            self.cap > 0,
+            "when data ptr is not null capacity must always be larger than 0"
+        );
+        debug_assert!(
+            self.cap > self.inner.len(),
+            "allocated capacity must always be bigger than length"
+        );
+        self.cap - self.inner.len() - 1
+    }
+
+    /// Returns the minimum capacity needed to allocate `additional` bytes, or
+    /// `None` if the current capacity is already large enough.
+    #[inline]
+    fn min_capacity_for_additional(
+        &self,
+        additional: usize,
+    ) -> Option<NonZeroUsize> {
+        let remaining = self.remaining_capacity();
+        if remaining >= additional {
+            return None;
+        }
+        if self.inner.data.is_null() {
+            debug_assert_eq!(self.cap, 0);
+            NonZeroUsize::new(additional + 1)
+        } else {
+            NonZeroUsize::new(self.cap + additional - remaining)
+        }
+    }
+}
+
+impl Default for StringBuilder {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Write for StringBuilder {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push_bytes(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl Drop for StringBuilder {
+    fn drop(&mut self) {
+        if !self.inner.data.is_null() {
+            unsafe { libc::free(self.inner.data as *mut ffi::c_void) }
+        }
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn unable_to_alloc_memory() {
+    panic!("unable to alloc memory with libc::realloc")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder() {
+        let s = "foo bar";
+        let bytes = b"baz foo bar";
+
+        let mut sb = StringBuilder::new();
+        sb.push_bytes(s.as_bytes());
+        sb.push_bytes(bytes);
+
+        assert_eq!(sb.inner.len, s.len() + bytes.len());
+        assert_eq!(sb.cap, 32); // Allocation size
+        assert_eq!(unsafe { *sb.inner.data.add(sb.inner.len) }, 0); // Null termination
+
+        let nv_str = sb.finish();
+        assert_eq!(nv_str.len(), s.len() + bytes.len());
+    }
+
+    #[test]
+    fn with_capacity() {
+        let s = StringBuilder::with_capacity(0);
+        assert!(!s.inner.data.is_null());
+        assert_eq!(s.cap, 1);
+        assert_eq!(s.inner.len(), 0);
+        s.finish();
+        let s = StringBuilder::with_capacity(1);
+        assert_eq!(s.cap, 2);
+        assert_eq!(s.inner.len(), 0);
+        s.finish();
+        let s = StringBuilder::with_capacity(5);
+        assert_eq!(s.cap, 6);
+        assert_eq!(s.inner.len(), 0);
+        s.finish();
+    }
+
+    #[test]
+    fn reserve() {
+        let mut sb = StringBuilder::new();
+        assert_eq!(sb.cap, 0);
+        sb.reserve(10);
+        assert_eq!(sb.cap, 16);
+
+        // Shouldn't change the pointer address as we have enough space.
+        sb.reserve(10);
+        assert_eq!(sb.cap, 16);
+        let ptr = sb.inner.data;
+        sb.push_bytes(b"Hello World!");
+        // We already allocated the space needed the push above shouldn't
+        // change the pointer.
+        assert_eq!(sb.inner.data, ptr);
+        sb.push_bytes(&[b'a'; 55]);
+        // We shouldn't check the pointer again as the block might be extended
+        // instead of being moved to a different address.
+        assert_eq!(unsafe { *sb.inner.data.add(sb.inner.len) }, 0);
+        assert_eq!(sb.cap, 128);
+    }
+
+    #[test]
+    fn reserve_exact() {
+        let mut sb = StringBuilder::new();
+        sb.reserve_exact(10);
+        assert_eq!(sb.cap, 11);
+        let ptr = sb.inner.data;
+        sb.push_bytes(b"hi");
+        assert_eq!(sb.inner.len(), 2);
+
+        // The space is already allocated, pushing bytes shouldn't change the
+        // ptr address.
+        assert_eq!(ptr, sb.inner.data);
+        sb.push_bytes(b"Hello World!");
+        assert_eq!(sb.cap, 16);
+        assert_eq!(sb.inner.len(), 14);
+        let ptr = sb.inner.data;
+        sb.push_bytes(b"c");
+        assert_eq!(sb.inner.data, ptr);
+    }
+}

--- a/crates/types/src/string_builder.rs
+++ b/crates/types/src/string_builder.rs
@@ -1,6 +1,6 @@
-use core::ffi;
 use core::fmt;
 use core::num::NonZeroUsize;
+use core::{ffi, ptr};
 
 use crate::String as NvimString;
 
@@ -17,7 +17,12 @@ impl StringBuilder {
     /// Create a new empty `StringBuilder`.
     #[inline]
     pub fn new() -> Self {
-        Self { inner: NvimString::new(), cap: 0 }
+        Self {
+            // SAFETY: even though the pointer is temporarily null, it'll
+            // be set to a valid pointer by the time `finish` is called.
+            inner: unsafe { NvimString::from_raw_parts(ptr::null_mut(), 0) },
+            cap: 0,
+        }
     }
 
     /// Push new bytes to the builder.
@@ -157,7 +162,7 @@ impl StringBuilder {
 
     /// Returns the remaining *usable* capacity, i.e. the remaining capacity
     /// minus the space reserved for the null terminator.
-    #[inline(always)]
+    #[inline]
     fn remaining_capacity(&self) -> usize {
         if self.inner.as_ptr().is_null() {
             debug_assert_eq!(self.inner.len(), 0);


### PR DESCRIPTION
This PR adds `NvimStr`, which is to `nvim_oxi::String` (soon to be renamed to `NvimString`) what a `&str` is to a `String`, and re-implements `String` on top of an `NvimStr<'static>`.

One important distinction is that because `NvimStr`'s layout has to match Neovim's, it cannot be an unsized type. This implies that it'll often be used as `NvimStr<'a>` instead of `&'a NvimStr`, and that `NvimString` cannot implement `Deref<Target = NvimStr>`.

We *could* implement `Deref<Target = NvimStr<'a>> for &'a NvimString`, but that doesn't compile due to conflicting implementations with the blanket impl of `Deref for &T`.

The reason for adding this is that I plan to eventually change the signature of all the API functions taking `&str`s as parameters to taking any `impl Into<NvimStr>`. As of today that would be a massive breaking change because we can't implement `From<&str> for NvimStr`, but that'll be resolved by implementing https://github.com/neovim/neovim/issues/31862.