### PR TITLE
refactor: make `NvimStr`'s data pointer `*const`

### DIFF
--- a/crates/types/src/object.rs
+++ b/crates/types/src/object.rs
@@ -343,11 +343,11 @@ impl Object {
     /// [`String`][ObjectKind::String]. Calling this method on an `Object` with
     /// any other kind may result in undefined behavior.
     #[cfg_attr(debug_assertions, track_caller)]
-    pub unsafe fn into_string_unchecked(mut self) -> NvimString {
+    pub unsafe fn into_string_unchecked(self) -> NvimString {
         debug_assert!(self.ty == ObjectKind::String, "{:?}", self.ty);
-        let string = &mut self.data.string;
+        let string = &self.data.string;
         let string = unsafe {
-            NvimString::from_raw_parts(string.as_mut_ptr(), string.len())
+            NvimString::from_raw_parts(string.as_ptr(), string.len())
         };
         core::mem::forget(self);
         string

--- a/crates/types/src/str.rs
+++ b/crates/types/src/str.rs
@@ -9,7 +9,7 @@ use crate::String as NvimString;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct NvimStr<'a> {
-    data: *mut ffi::c_char,
+    data: *const ffi::c_char,
     len: usize,
     _lifetime: PhantomData<&'a ()>,
 }
@@ -41,12 +41,6 @@ impl<'a> NvimStr<'a> {
         self.data as *const ffi::c_char
     }
 
-    /// Returns a raw pointer to the [`NvimStr`]'s buffer.
-    #[inline]
-    pub const fn as_mut_ptr(&mut self) -> *mut ffi::c_char {
-        self.data
-    }
-
     /// Creates an `NvimStr` from a pointer to the underlying data and a
     /// length.
     ///
@@ -55,7 +49,10 @@ impl<'a> NvimStr<'a> {
     /// The caller must ensure that the pointer is valid for `len + 1`
     /// elements and that the last element is a null byte.
     #[inline]
-    pub unsafe fn from_raw_parts(data: *mut ffi::c_char, len: usize) -> Self {
+    pub unsafe fn from_raw_parts(
+        data: *const ffi::c_char,
+        len: usize,
+    ) -> Self {
         Self { data, len, _lifetime: PhantomData }
     }
 

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -16,7 +16,7 @@ use crate::StringBuilder;
 /// Unlike Rust's `String`, this type is not guaranteed to contain valid UTF-8
 /// byte sequences, it can contain null bytes, and it is null-terminated.
 //
-// https://github.com/neovim/neovim/blob/v0.9.0/src/nvim/api/private/defs.h#L79-L82
+// https://github.com/neovim/neovim/blob/v0.11.0/src/nvim/api/private/defs.h#L80-L83
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct String {
@@ -33,12 +33,6 @@ impl String {
     #[inline]
     pub fn as_ptr(&self) -> *const ffi::c_char {
         self.inner.as_ptr()
-    }
-
-    /// Returns a pointer to the `String`'s buffer.
-    #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::c_char {
-        self.inner.as_mut_ptr()
     }
 
     /// Returns an [`NvimStr`] view of this `String`.
@@ -64,7 +58,10 @@ impl String {
     /// The caller must ensure that the pointer is valid for `len + 1`
     /// elements and that the last element is a null byte.
     #[inline]
-    pub unsafe fn from_raw_parts(data: *mut ffi::c_char, len: usize) -> Self {
+    pub unsafe fn from_raw_parts(
+        data: *const ffi::c_char,
+        len: usize,
+    ) -> Self {
         Self { inner: NvimStr::from_raw_parts(data, len) }
     }
 


### PR DESCRIPTION
Both `String` and `NvimStr` are immutable, so this is more semantically correct.