### PR TITLE
feat: implement `From<&CStr>` for `NvimStr`

### DIFF
--- a/crates/types/src/str.rs
+++ b/crates/types/src/str.rs
@@ -1,11 +1,16 @@
+use core::ffi::{self, CStr};
 use core::marker::PhantomData;
 use core::str::Utf8Error;
-use core::{cmp, ffi, fmt, hash, slice};
+use core::{cmp, fmt, hash, slice};
 use std::borrow::Cow;
 
 use crate::String as NvimString;
 
-/// TODO: docs.
+/// A borrowed version of [`NvimString`].
+///
+/// Values of this type can be created by calling
+/// [`as_nvim_str`](NvimString::as_nvim_str) on a [`NvimString`] or by
+/// converting a [`CStr`].
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct NvimStr<'a> {
@@ -166,5 +171,16 @@ impl<'a> From<&'a NvimString> for NvimStr<'a> {
     #[inline]
     fn from(string: &'a NvimString) -> Self {
         string.as_nvim_str()
+    }
+}
+
+impl<'a> From<&'a CStr> for NvimStr<'a> {
+    #[inline]
+    fn from(cstr: &'a CStr) -> Self {
+        Self {
+            data: cstr.as_ptr(),
+            len: cstr.to_bytes().len(),
+            _lifetime: PhantomData,
+        }
     }
 }

--- a/crates/types/src/str.rs
+++ b/crates/types/src/str.rs
@@ -151,6 +151,13 @@ impl PartialEq for NvimStr<'_> {
     }
 }
 
+impl PartialEq<&str> for NvimStr<'_> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
 impl Eq for NvimStr<'_> {}
 
 impl PartialOrd for NvimStr<'_> {
@@ -182,5 +189,24 @@ impl<'a> From<&'a CStr> for NvimStr<'a> {
             len: cstr.to_bytes().len(),
             _lifetime: PhantomData,
         }
+    }
+}
+
+impl PartialEq<NvimStr<'_>> for &str {
+    #[inline]
+    fn eq(&self, other: &NvimStr<'_>) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_cstr() {
+        let c_str = c"Hello, World!";
+        let nvim_str = NvimStr::from(c_str);
+        assert_eq!(nvim_str, "Hello, World!");
     }
 }


### PR DESCRIPTION
It's not possible to also implement the opposite conversion, i.e. `From<NvimStr> for &CStr`, because IIRC Neovim strings are not guaranteed to not contain NULL bytes other than the final one.