### PR TITLE
feat: add a `max_height` field to `WinTextHeightOpts` on Nightly

### DIFF
--- a/crates/api/src/opts/win_text_height.rs
+++ b/crates/api/src/opts/win_text_height.rs
@@ -24,4 +24,13 @@ pub struct WinTextHeightOpts {
     /// to full screen lines. When omitted include the whole line.
     #[builder(argtype = "usize", inline = "{0} as types::Integer")]
     end_vcol: types::Integer,
+
+    // Don't add the height of lines below the row for which this height is
+    // reached. Useful to e.g. limit the height to the window height, avoiding
+    // unnecessary work. Or to find out how many buffer lines beyond
+    // [`start_row`](Self::start_row) take up a certain number of logical lines
+    // (returned in `end_row` and `end_vcol`).
+    #[cfg(feature = "neovim-nightly")] // Only on Nightly.
+    #[builder(argtype = "usize", inline = "{0} as types::Integer")]
+    max_height: types::Integer,
 }


### PR DESCRIPTION
Upstream:
https://github.com/neovim/neovim/commit/7ba043f0f31cc0c9a783bcb28d6f700a42ba6ff4