### PR TITLE
feat: add a hidden `_cmdline_offset` field to `WindowOpts` on Nightly

### DIFF
--- a/crates/api/src/types/window_config.rs
+++ b/crates/api/src/types/window_config.rs
@@ -308,6 +308,9 @@ pub struct WindowOpts {
     noautocmd: Boolean,
     fixed: Boolean,
     hide: Boolean,
+    #[cfg(feature = "neovim-nightly")] // Only on Nightly.
+    #[builder(skip)]
+    _cmdline_offset: Integer,
 }
 
 impl From<&WindowConfig> for WindowOpts {


### PR DESCRIPTION
Upstream:
https://github.com/neovim/neovim/commit/08c484f2ca4b58e9eda07e194e9d096565db7144