### PR TITLE
fix(api): make `KeymapInfos::buffer` an `Option<Buffer>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - `nvim_oxi::api::get_mode()` is now infallible and always returns a `GotMode`
   ([#247](https://github.com/noib3/nvim-oxi/pull/247));
 
+- `nvim_oxi::api::KeymapInfos::buffer` is now an `Option<Buffer>` instead of
+  a `bool` ([#255](https://github.com/noib3/nvim-oxi/pull/255));
+
 ### Fixed
 
 - fixed the definition of `DecorationProviderOpts`, which was causing

--- a/crates/api/src/buffer.rs
+++ b/crates/api/src/buffer.rs
@@ -27,6 +27,7 @@ use crate::{Error, IntoResult, Result};
 
 /// A wrapper around a Neovim buffer handle.
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Buffer(pub(crate) BufHandle);
 
 impl fmt::Debug for Buffer {

--- a/crates/api/src/types/keymap_infos.rs
+++ b/crates/api/src/types/keymap_infos.rs
@@ -7,14 +7,16 @@ use types::{
 };
 
 use super::Mode;
-use crate::serde_utils as utils;
+use crate::{Buffer, serde_utils as utils};
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize)]
 pub struct KeymapInfos {
-    /// Whether the mapping is local to a specific buffer.
-    #[serde(deserialize_with = "utils::bool_from_int")]
-    pub buffer: bool,
+    /// When the [`KeymapInfos`] are returned from [`Buffer::get_keymap()`],
+    /// this will contain the [`Buffer`] it was called on. `None` when returned
+    /// from [`get_keymap()`](crate::get_keymap).
+    #[serde(deserialize_with = "utils::zero_is_none")]
+    pub buffer: Option<Buffer>,
 
     /// Optional callback triggered by the keymap.
     pub callback: Option<Function<(), ()>>,

--- a/tests/src/api/buffer.rs
+++ b/tests/src/api/buffer.rs
@@ -158,7 +158,7 @@ fn buf_set_get_del_keymap() {
 
     let keymaps = buf.get_keymap(Mode::Insert).unwrap().collect::<Vec<_>>();
     assert_eq!(1, keymaps.len());
-    // assert_eq!(keymaps[0].buffer, Some(buf.clone()));
+    assert!(keymaps.iter().all(|keymap| keymap.buffer == Some(buf.clone())));
 
     let res = buf.del_keymap(Mode::Insert, "a");
     assert_eq!(Ok(()), res);
@@ -182,7 +182,7 @@ fn buf_set_get_keymap_with_bufnr_more_than_one() {
 
     let keymaps = buf.get_keymap(Mode::Insert).unwrap().collect::<Vec<_>>();
     assert_eq!(1, keymaps.len());
-    // assert_eq!(keymaps[0].buffer, Some(buf.clone()));
+    assert!(keymaps.iter().all(|keymap| keymap.buffer == Some(buf.clone())));
 }
 
 #[nvim_oxi::test]
@@ -202,7 +202,7 @@ fn buf_set_get_del_nvo_keymap() {
         .unwrap()
         .collect::<Vec<_>>();
     assert_le!(1, keymaps.len());
-    // assert_eq!(keymaps[0].buffer, Some(buf.clone()));
+    assert!(keymaps.iter().all(|keymap| keymap.buffer == Some(buf.clone())));
 
     let res = buf.del_keymap(Mode::NormalVisualOperator, "a");
     assert_eq!(Ok(()), res);

--- a/tests/src/api/buffer.rs
+++ b/tests/src/api/buffer.rs
@@ -158,9 +158,31 @@ fn buf_set_get_del_keymap() {
 
     let keymaps = buf.get_keymap(Mode::Insert).unwrap().collect::<Vec<_>>();
     assert_eq!(1, keymaps.len());
+    // assert_eq!(keymaps[0].buffer, Some(buf.clone()));
 
     let res = buf.del_keymap(Mode::Insert, "a");
     assert_eq!(Ok(()), res);
+}
+
+/// Regression test for https://github.com/noib3/nvim-oxi/issues/226
+#[nvim_oxi::test]
+fn buf_set_get_keymap_with_bufnr_more_than_one() {
+    let mut buf = api::create_buf(true, false).unwrap();
+
+    assert!(buf.handle() > 1);
+
+    let opts = SetKeymapOpts::builder()
+        .callback(|_| ())
+        .desc("does nothing")
+        .expr(true)
+        .build();
+
+    let res = buf.set_keymap(Mode::Insert, "a", "", &opts);
+    assert_eq!(Ok(()), res);
+
+    let keymaps = buf.get_keymap(Mode::Insert).unwrap().collect::<Vec<_>>();
+    assert_eq!(1, keymaps.len());
+    // assert_eq!(keymaps[0].buffer, Some(buf.clone()));
 }
 
 #[nvim_oxi::test]
@@ -180,6 +202,7 @@ fn buf_set_get_del_nvo_keymap() {
         .unwrap()
         .collect::<Vec<_>>();
     assert_le!(1, keymaps.len());
+    // assert_eq!(keymaps[0].buffer, Some(buf.clone()));
 
     let res = buf.del_keymap(Mode::NormalVisualOperator, "a");
     assert_eq!(Ok(()), res);

--- a/tests/src/api/global.rs
+++ b/tests/src/api/global.rs
@@ -254,6 +254,7 @@ fn set_get_del_keymap() {
 
     let keymaps = api::get_keymap(Mode::Insert).collect::<Vec<_>>();
     assert_le!(1, keymaps.len());
+    assert!(keymaps.iter().all(|keymap| keymap.buffer.is_none()));
 
     let res = api::del_keymap(Mode::Insert, "a");
     assert_eq!(Ok(()), res);


### PR DESCRIPTION
The `buffer` key of the dictionaries returned by `nvim_buf_get_keymap` is always set to the bufnr or the buffer it was called on ([upstream](https://github.com/neovim/neovim/blob/00bec1fd90a383ad54f17504557d9fef7d746b5b/src/nvim/mapping.c#L2130)).

Closes #226.