### PR TITLE
when error, ruturn nil, not lua_error

### DIFF
--- a/crates/api/src/buffer.rs
+++ b/crates/api/src/buffer.rs
@@ -79,10 +79,7 @@ impl Poppable for Buffer {
 }
 
 impl Pushable for Buffer {
-    unsafe fn push(
-        self,
-        lstate: *mut lua::ffi::State,
-    ) -> std::result::Result<std::ffi::c_int, lua::Error> {
+    unsafe fn push(self, lstate: *mut lua::ffi::State) -> std::ffi::c_int {
         unsafe { self.0.push(lstate) }
     }
 }

--- a/crates/api/src/tabpage.rs
+++ b/crates/api/src/tabpage.rs
@@ -53,10 +53,7 @@ impl Poppable for TabPage {
 }
 
 impl Pushable for TabPage {
-    unsafe fn push(
-        self,
-        lstate: *mut lua::ffi::State,
-    ) -> std::result::Result<std::ffi::c_int, lua::Error> {
+    unsafe fn push(self, lstate: *mut lua::ffi::State) -> std::ffi::c_int {
         self.0.push(lstate)
     }
 }

--- a/crates/api/src/window.rs
+++ b/crates/api/src/window.rs
@@ -70,10 +70,7 @@ impl Poppable for Window {
 }
 
 impl Pushable for Window {
-    unsafe fn push(
-        self,
-        lstate: *mut lua::ffi::State,
-    ) -> std::result::Result<std::ffi::c_int, lua::Error> {
+    unsafe fn push(self, lstate: *mut lua::ffi::State) -> std::ffi::c_int {
         self.0.push(lstate)
     }
 }

--- a/crates/luajit/src/pushable.rs
+++ b/crates/luajit/src/pushable.rs
@@ -2,33 +2,33 @@ use core::ffi::{c_char, c_int};
 
 use crate::ffi::{self, Integer, Number, State};
 use crate::macros::count;
-use crate::utils;
+use crate::utils::{self, push_error};
 
 /// Trait implemented for types that can be pushed onto the Lua stack.
 pub trait Pushable {
     /// Pushes all its values on the Lua stack, returning the number of values
     /// that it pushed.
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error>;
+    unsafe fn push(self, lstate: *mut State) -> c_int;
 }
 
 impl Pushable for () {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         ffi::lua_pushnil(lstate);
-        Ok(1)
+        1
     }
 }
 
 impl Pushable for bool {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         ffi::lua_pushboolean(lstate, self as _);
-        Ok(1)
+        1
     }
 }
 
 impl Pushable for Integer {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         ffi::lua_pushinteger(lstate, self);
-        Ok(1)
+        1
     }
 }
 
@@ -37,10 +37,7 @@ impl Pushable for Integer {
 macro_rules! push_into_integer {
     ($integer:ty) => {
         impl Pushable for $integer {
-            unsafe fn push(
-                self,
-                lstate: *mut State,
-            ) -> Result<c_int, crate::Error> {
+            unsafe fn push(self, lstate: *mut State) -> c_int {
                 let n: Integer = self.into();
                 n.push(lstate)
             }
@@ -53,18 +50,15 @@ macro_rules! push_into_integer {
 macro_rules! push_try_into_integer {
     ($integer:ty) => {
         impl Pushable for $integer {
-            unsafe fn push(
-                self,
-                lstate: *mut State,
-            ) -> Result<c_int, crate::Error> {
-                let n: Integer = self.try_into().map_err(
+            unsafe fn push(self, lstate: *mut State) -> c_int {
+                let n: Result<Integer, _> = self.try_into().map_err(
                     |err: std::num::TryFromIntError| {
                         crate::Error::push_error(
                             std::any::type_name::<$integer>(),
                             err.to_string(),
                         )
                     },
-                )?;
+                );
                 n.push(lstate)
             }
         }
@@ -82,26 +76,26 @@ push_try_into_integer!(u64);
 push_try_into_integer!(usize);
 
 impl Pushable for Number {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         ffi::lua_pushnumber(lstate, self);
-        Ok(1)
+        1
     }
 }
 
 impl Pushable for f32 {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         (self as Number).push(lstate)
     }
 }
 
 impl Pushable for String {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         ffi::lua_pushlstring(
             lstate,
             self.as_ptr() as *const c_char,
             self.len(),
         );
-        Ok(1)
+        1
     }
 }
 
@@ -109,7 +103,7 @@ impl<T> Pushable for Option<T>
 where
     T: Pushable,
 {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         match self {
             Some(t) => t.push(lstate),
             None => ().push(lstate),
@@ -121,31 +115,32 @@ impl<T> Pushable for Vec<T>
 where
     T: Pushable,
 {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         ffi::lua_createtable(lstate, self.len() as _, 0);
 
         for (i, obj) in self.into_iter().enumerate() {
-            obj.push(lstate)?;
+            obj.push(lstate);
             ffi::lua_rawseti(lstate, -2, (i + 1) as _);
         }
 
-        Ok(1)
+        1
     }
 }
 
 impl<T, E> Pushable for Result<T, E>
 where
     T: Pushable,
-    E: core::fmt::Display,
+    E: std::error::Error,
 {
     #[inline]
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, crate::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         match self {
             Ok(value) => value.push(lstate),
-            Err(err) => utils::push_error(&err, lstate),
+            Err(err) => push_error(&err, lstate),
         }
     }
 }
+
 /// Implements `LuaPushable` for a tuple `(a, b, c, ..)` where all the elements
 /// in the tuple implement `LuaPushable`.
 macro_rules! push_tuple {
@@ -158,10 +153,10 @@ macro_rules! push_tuple {
             unsafe fn push(
                 self,
                 lstate: *mut State,
-            ) -> Result<c_int, crate::Error> {
+            ) -> c_int {
                 let ($($name,)*) = self;
-                $($name.push(lstate)?;)*
-                Ok(count!($($name)*))
+                $($name.push(lstate);)*
+                count!($($name)*)
             }
         }
     }

--- a/crates/luajit/src/utils.rs
+++ b/crates/luajit/src/utils.rs
@@ -75,11 +75,11 @@ pub unsafe fn debug_stack(lstate: *mut State) {
 pub unsafe fn push_error<E: core::fmt::Display + ?Sized>(
     err: &E,
     lstate: *mut State,
-) -> ! {
-    let msg = err.to_string();
-    ffi::lua_pushlstring(lstate, msg.as_ptr() as *const _, msg.len());
-    drop(msg);
-    ffi::lua_error(lstate);
+) -> c_int {
+    //TODO Print error message to nvim, need crate a ffi crate
+    // let msg = err.to_string();
+    ffi::lua_pushnil(lstate);
+    1
 }
 
 pub fn type_name(ty: c_int) -> &'static str {

--- a/crates/types/src/array.rs
+++ b/crates/types/src/array.rs
@@ -204,10 +204,7 @@ impl lua::Poppable for Array {
 
 impl lua::Pushable for Array {
     #[inline]
-    unsafe fn push(
-        self,
-        lstate: *mut lua::ffi::State,
-    ) -> Result<core::ffi::c_int, lua::Error> {
+    unsafe fn push(self, lstate: *mut lua::ffi::State) -> core::ffi::c_int {
         use lua::ffi::*;
 
         lua_createtable(lstate, self.len() as _, 0);
@@ -215,11 +212,11 @@ impl lua::Pushable for Array {
         for (idx, obj) in
             self.into_iter().filter(|obj| !obj.is_nil()).enumerate()
         {
-            obj.push(lstate)?;
+            obj.push(lstate);
             lua_rawseti(lstate, -2, (idx + 1) as _);
         }
 
-        Ok(1)
+        1
     }
 }
 

--- a/crates/types/src/dictionary.rs
+++ b/crates/types/src/dictionary.rs
@@ -423,21 +423,18 @@ impl lua::Poppable for Dictionary {
 
 impl lua::Pushable for Dictionary {
     #[inline]
-    unsafe fn push(
-        self,
-        lstate: *mut lua::ffi::State,
-    ) -> Result<core::ffi::c_int, lua::Error> {
+    unsafe fn push(self, lstate: *mut lua::ffi::State) -> core::ffi::c_int {
         use lua::ffi::*;
 
         lua_createtable(lstate, 0, self.len() as _);
 
         for (key, obj) in self.into_iter().filter(|(_, obj)| !obj.is_nil()) {
             lua_pushlstring(lstate, key.as_ptr(), key.len());
-            obj.push(lstate)?;
+            obj.push(lstate);
             lua_rawset(lstate, -3);
         }
 
-        Ok(1)
+        1
     }
 }
 

--- a/crates/types/src/function.rs
+++ b/crates/types/src/function.rs
@@ -62,12 +62,9 @@ impl<A, R> Poppable for Function<A, R> {
 }
 
 impl<A, R> Pushable for Function<A, R> {
-    unsafe fn push(
-        self,
-        state: *mut lua::ffi::State,
-    ) -> Result<c_int, lua::Error> {
+    unsafe fn push(self, state: *mut lua::ffi::State) -> c_int {
         ffi::lua_rawgeti(state, ffi::LUA_REGISTRYINDEX, self.lua_ref);
-        Ok(1)
+        1
     }
 }
 

--- a/crates/types/src/object.rs
+++ b/crates/types/src/object.rs
@@ -700,7 +700,7 @@ where
 }
 
 impl Pushable for Object {
-    unsafe fn push(self, lstate: *mut State) -> Result<c_int, lua::Error> {
+    unsafe fn push(self, lstate: *mut State) -> c_int {
         match self.kind() {
             ObjectKind::Nil => ().push(lstate),
             ObjectKind::Boolean => self.as_boolean_unchecked().push(lstate),

--- a/crates/types/src/string.rs
+++ b/crates/types/src/string.rs
@@ -257,12 +257,9 @@ impl TryFrom<Object> for String {
 
 impl lua::Pushable for String {
     #[inline]
-    unsafe fn push(
-        self,
-        lstate: *mut lua::ffi::State,
-    ) -> Result<ffi::c_int, lua::Error> {
+    unsafe fn push(self, lstate: *mut lua::ffi::State) -> ffi::c_int {
         lua::ffi::lua_pushlstring(lstate, self.as_ptr(), self.len());
-        Ok(1)
+        1
     }
 }
 

--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -19,9 +19,6 @@ where
         #[cfg(feature = "libuv")]
         libuv::init(lua_state);
 
-        match body().push(lua_state) {
-            Ok(num_pushed) => num_pushed,
-            Err(lua_err) => luajit::utils::push_error(&lua_err, lua_state),
-        }
+        body().push(lua_state)
     }
 }


### PR DESCRIPTION
Resolved the issue of the Rust stack not being able to unwind due to lua_error. : https://github.com/noib3/nvim-oxi/issues/231