### PR TITLE
fix: update `WindowOpts` layout on 0.12

### DIFF
--- a/crates/api/src/types/window_config.rs
+++ b/crates/api/src/types/window_config.rs
@@ -278,6 +278,7 @@ impl FromObject for WindowConfig {
 
 #[derive(Clone, Default, Debug, macros::OptsBuilder)]
 #[repr(C)]
+#[cfg(not(feature = "neovim-0-12"))] // On 0.11 Only
 pub struct WindowOpts {
     #[builder(mask)]
     mask: u64,
@@ -304,7 +305,37 @@ pub struct WindowOpts {
     noautocmd: Boolean,
     fixed: Boolean,
     hide: Boolean,
-    #[cfg(feature = "neovim-0-12")] // On 0.12 and Nightly.
+}
+
+#[derive(Clone, Default, Debug, macros::OptsBuilder)]
+#[repr(C)]
+#[cfg(feature = "neovim-0-12")] // On 0.12 and Nightly.
+pub struct WindowOpts {
+    #[builder(mask)]
+    mask: u64,
+    external: Boolean,
+    fixed: Boolean,
+    focusable: Boolean,
+    footer: Object,
+    footer_pos: NvimString,
+    hide: Boolean,
+    height: Integer,
+    mouse: Boolean,
+    relative: NvimString,
+    row: Float,
+    style: NvimString,
+    noautocmd: Boolean,
+    vertical: Boolean,
+    win: WinHandle,
+    width: Integer,
+    zindex: Integer,
+    anchor: NvimString,
+    border: Object,
+    bufpos: Array,
+    col: Float,
+    split: NvimString,
+    title: Object,
+    title_pos: NvimString,
     #[builder(skip)]
     _cmdline_offset: Integer,
 }

--- a/crates/api/src/types/window_config.rs
+++ b/crates/api/src/types/window_config.rs
@@ -488,8 +488,10 @@ impl TryFrom<WindowOpts> for WindowConfig {
         enum WindowRelative {
             Editor,
             Win,
+            Laststatus,
             Cursor,
             Mouse,
+            Tabline,
         }
 
         let relative = match utils::empty_string_is_none(Deserializer::new(
@@ -501,8 +503,12 @@ impl TryFrom<WindowOpts> for WindowConfig {
                     let win = deserialize(win)?;
                     Some(WindowRelativeTo::Window(win))
                 },
+                WindowRelative::Laststatus => {
+                    Some(WindowRelativeTo::Laststatus)
+                },
                 WindowRelative::Cursor => Some(WindowRelativeTo::Cursor),
                 WindowRelative::Mouse => Some(WindowRelativeTo::Mouse),
+                WindowRelative::Tabline => Some(WindowRelativeTo::Tabline),
             },
             None => None,
         };

--- a/crates/api/src/types/window_relative_to.rs
+++ b/crates/api/src/types/window_relative_to.rs
@@ -11,11 +11,17 @@ pub enum WindowRelativeTo {
     /// Positions the window relative to the global Neovim editor grid.
     Editor,
 
+    /// Positions the window relative to the status line if present, or last row.
+    Laststatus,
+
     /// Positions the window relative to the current cursor position.
     Cursor,
 
     /// Positions the window relative to the current mouse cursor position..
     Mouse,
+
+    /// Positions the window relative to the tabline if present, or first row.
+    Tabline,
 
     /// Positions the window relative to another window.
     #[serde(untagged)]
@@ -27,8 +33,10 @@ impl From<WindowRelativeTo> for NvimString {
         match pos {
             WindowRelativeTo::Editor => "editor",
             WindowRelativeTo::Window(_) => "win",
+            WindowRelativeTo::Laststatus => "laststatus",
             WindowRelativeTo::Cursor => "cursor",
             WindowRelativeTo::Mouse => "mouse",
+            WindowRelativeTo::Tabline => "tabline",
         }
         .into()
     }


### PR DESCRIPTION
Depends on #295 for `neovim-0-12` feature flag.

Updates the layout of the `WindowOpts` struct to it's corresponding layout in NVIM v0.12.0.

This resolves test failures on v0.12 and Nightly for:
```
api::tabpage::tabpage_set_get_win
api::win_config::open_hsplit
api::win_config::open_split_win
api::win_config::open_win_basic_config
api::win_config::open_win_full_config
api::win_config::open_win_get_set_footer
api::win_config::set_config
api::window::close_hide
api::window::get_set_height_width
```