### PR TITLE
api: fix `SetHighlightOpts` layout on 0.12 and Nightly

### DIFF
--- a/crates/api/src/opts/set_highlight.rs
+++ b/crates/api/src/opts/set_highlight.rs
@@ -4,6 +4,7 @@ use types::{Boolean, Integer, String as NvimString};
 // https://github.com/neovim/neovim/blob/v0.11.3/src/nvim/api/keysets_defs.h#L164-L196
 #[derive(Clone, Debug, Default, PartialEq, macros::OptsBuilder)]
 #[repr(C)]
+#[cfg(not(feature = "neovim-0-12"))] // On 0.11 Only
 pub struct SetHighlightOpts {
     #[builder(mask)]
     mask: u64,
@@ -101,6 +102,127 @@ pub struct SetHighlightOpts {
 
     #[builder(argtype = "bool")]
     force: Boolean,
+
+    #[builder(skip)]
+    url: NvimString,
+}
+
+// https://github.com/neovim/neovim/blob/v0.12.0/src/nvim/api/keysets_defs.h#L174-211
+#[derive(Clone, Debug, Default, PartialEq, macros::OptsBuilder)]
+#[repr(C)]
+#[cfg(feature = "neovim-0-12")] // On 0.12 and Nightly.
+pub struct SetHighlightOpts {
+    #[builder(mask)]
+    mask: u64,
+
+    #[builder(argtype = "bool")]
+    altfont: Boolean,
+
+    #[builder(argtype = "bool")]
+    blink: Boolean,
+
+    #[builder(argtype = "bool")]
+    bold: Boolean,
+
+    #[builder(argtype = "bool")]
+    conceal: Boolean,
+
+    #[builder(argtype = "bool")]
+    dim: Boolean,
+
+    #[builder(argtype = "bool")]
+    italic: Boolean,
+
+    #[builder(argtype = "bool")]
+    nocombine: Boolean,
+
+    #[builder(argtype = "bool")]
+    overline: Boolean,
+
+    #[builder(argtype = "bool")]
+    reverse: Boolean,
+
+    #[builder(argtype = "bool")]
+    standout: Boolean,
+
+    #[builder(argtype = "bool")]
+    strikethrough: Boolean,
+
+    #[builder(argtype = "bool")]
+    undercurl: Boolean,
+
+    #[builder(argtype = "bool")]
+    underdashed: Boolean,
+
+    #[builder(argtype = "bool")]
+    underdotted: Boolean,
+
+    #[builder(argtype = "bool")]
+    underdouble: Boolean,
+
+    #[builder(argtype = "bool")]
+    underline: Boolean,
+
+    #[builder(method = "builder", argtype = "bool")]
+    // The field name is actually `default_`, but I think it somehow gets
+    // converted to `default` at build time because the correct mask index
+    // is obtained with `default`.
+    default: Boolean,
+
+    #[builder(argtype = "&str", inline = "types::String::from({0}).into()")]
+    cterm: Object, // TODO: check highlight_cterm object is `highlight_cterm`
+
+    #[builder(argtype = "&str", inline = "types::String::from({0}).into()")]
+    foreground: Object,
+
+    #[builder(skip)]
+    fg: Object,
+
+    #[builder(argtype = "&str", inline = "types::String::from({0}).into()")]
+    background: Object,
+
+    #[builder(skip)]
+    bg: Object,
+
+    #[builder(argtype = "&str", inline = "types::String::from({0}).into()")]
+    ctermfg: Object,
+
+    #[builder(argtype = "&str", inline = "types::String::from({0}).into()")]
+    ctermbg: Object,
+
+    #[builder(argtype = "&str", inline = "types::String::from({0}).into()")]
+    special: Object,
+
+    #[builder(skip)]
+    sp: Object,
+
+    #[builder(
+        generics = "Hl: crate::HlGroup",
+        argtype = "Hl",
+        inline = r#"{ let Ok(hl_id) = {0}.to_hl_id() else { return self; }; hl_id }"#
+    )]
+    link: types::HlGroupId,
+
+    #[builder(skip)]
+    global_link: types::HlGroupId,
+
+    #[builder(argtype = "bool")]
+    fallback: Boolean,
+
+    #[builder(argtype = "u8", inline = "{0} as Integer")]
+    blend: Integer,
+
+    #[builder(argtype = "bool")]
+    fg_indexed: Boolean,
+
+    #[builder(argtype = "bool")]
+    bg_indexed: Boolean,
+
+    #[builder(argtype = "bool")]
+    force: Boolean,
+
+    #[builder(argtype = "bool")]
+    update: Boolean,
 
     #[builder(skip)]
     url: NvimString,


### PR DESCRIPTION
Updates the layout of the `SetHighlightOpts` struct to it's corresponding layout in NVIM v0.12.0.

This resolves test failure on v0.12 and Nightly for `api::global::hl_underline`.

TODO:
- [ ] Add missing highlight values to `HighlightInfos`.
- [ ] Add `highlight_cterm` struct in accordance to [NVIM v0.12.0 defining it as a struct](https://github.com/neovim/neovim/blob/v0.12.0/src/nvim/api/keysets_defs.h#L193) in difference to it's definition as a [`Union(Integer, String)` in NVIM v0.11.7](https://github.com/neovim/neovim/blob/v0.11.7/src/nvim/api/keysets_defs.h#L179).
 
