### PR TITLE
Add vimscript function bindigs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "nvim-oxi-luajit",
  "nvim-oxi-macros",
  "nvim-oxi-types",
+ "nvim-oxi-vimfn",
  "serde",
  "thiserror",
  "tokio",
@@ -330,6 +331,20 @@ dependencies = [
  "libc",
  "nvim-oxi-luajit",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "nvim-oxi-vimfn"
+version = "0.6.0"
+dependencies = [
+ "mlua",
+ "nvim-oxi-api",
+ "nvim-oxi-luajit",
+ "nvim-oxi-macros",
+ "nvim-oxi-types",
+ "serde",
+ "serde_repr",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ libuv = { path = "./crates/libuv", package = "nvim-oxi-libuv" }
 luajit = { path = "./crates/luajit", package = "nvim-oxi-luajit" }
 macros = { path = "./crates/macros", package = "nvim-oxi-macros" }
 types = { path = "./crates/types", package = "nvim-oxi-types" }
+vimfn = { path = "./crates/vimfn", package = "nvim-oxi-vimfn" }
 
 [workspace.lints.clippy]
 mixed_attributes_style = "allow"
@@ -80,6 +81,7 @@ libuv = { workspace = true, optional = true }
 luajit = { workspace = true }
 macros = { workspace = true, features = ["plugin"] }
 types = { workspace = true, features = ["serde"] }
+vimfn = { workspace = true }
 
 cargo_metadata = { workspace = true, optional = true }
 mlua = { workspace = true, optional = true }

--- a/crates/api/src/opts/mod.rs
+++ b/crates/api/src/opts/mod.rs
@@ -30,6 +30,7 @@ mod set_extmark;
 mod set_highlight;
 mod set_keymap;
 mod set_mark;
+mod set_registry;
 mod win_text_height;
 
 pub use buf_attach::*;
@@ -61,4 +62,5 @@ pub use set_extmark::*;
 pub use set_highlight::*;
 pub use set_keymap::*;
 pub use set_mark::*;
+pub use set_registry::*;
 pub use win_text_height::*;

--- a/crates/api/src/opts/set_registry.rs
+++ b/crates/api/src/opts/set_registry.rs
@@ -1,0 +1,83 @@
+use std::{fmt::Display, str::FromStr};
+
+use types::{
+    Object,
+    conversion::{self, FromObject, ToObject},
+};
+
+use crate::types::RegisterType;
+
+#[derive(Clone, Debug, Default, PartialEq, macros::OptsBuilder)]
+pub struct SetregOpts {
+    set_unnamed: bool,
+    append: bool,
+    reg_type: RegisterType,
+}
+
+impl Display for SetregOpts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.set_unnamed {
+            write!(f, "u")?;
+        };
+        if self.append {
+            write!(f, "a")?;
+        };
+        write!(f, "{}", self.reg_type)
+    }
+}
+
+impl FromStr for SetregOpts {
+    type Err = conversion::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut set_unnamed = false;
+        let mut append = false;
+        let mut reg_type: Vec<u8> = Vec::with_capacity(s.len());
+
+        for byte in s.bytes() {
+            match byte {
+                b'u' => set_unnamed = true,
+                b'a' => append = true,
+                _ => reg_type.push(byte),
+            }
+        }
+
+        let reg_type = String::from_utf8_lossy(&reg_type).parse()?;
+
+        Ok(Self { set_unnamed, append, reg_type })
+    }
+}
+
+impl TryFrom<&str> for SetregOpts {
+    type Error = conversion::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl TryFrom<String> for SetregOpts {
+    type Error = conversion::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<SetregOpts> for String {
+    fn from(value: SetregOpts) -> Self {
+        value.to_string()
+    }
+}
+
+impl FromObject for SetregOpts {
+    fn from_object(obj: Object) -> Result<Self, conversion::Error> {
+        String::from_object(obj)?.parse()
+    }
+}
+
+impl ToObject for SetregOpts {
+    fn to_object(self) -> Result<Object, conversion::Error> {
+        self.to_string().to_object()
+    }
+}

--- a/crates/api/src/types/mod.rs
+++ b/crates/api/src/types/mod.rs
@@ -39,6 +39,7 @@ mod paste_phase;
 mod proc_infos;
 #[cfg(feature = "neovim-0-12")] // On 0.12 and Nightly.
 mod progress_message_status;
+mod register_infos;
 mod register_type;
 mod split_direction;
 mod split_modifier;
@@ -96,6 +97,7 @@ pub use paste_phase::*;
 pub use proc_infos::*;
 #[cfg(feature = "neovim-0-12")] // On 0.12 and Nightly.
 pub use progress_message_status::ProgressMessageStatus;
+pub use register_infos::*;
 pub use register_type::*;
 pub use split_direction::*;
 pub use split_modifier::*;

--- a/crates/api/src/types/register_infos.rs
+++ b/crates/api/src/types/register_infos.rs
@@ -1,0 +1,46 @@
+use macros::OptsBuilder;
+use serde::{Deserialize, Serialize, ser};
+use types::{
+    Object,
+    String as NvimString,
+    conversion::{self, FromObject, ToObject},
+    serde::{Deserializer, Serializer},
+};
+
+use crate::types::RegisterType;
+
+#[derive(
+    Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize, OptsBuilder,
+)]
+pub struct RegisterInfos {
+    #[serde(serialize_with = "serialize_as_vec_vec_bytes")]
+    pub regcontents: Vec<NvimString>,
+
+    pub regtype: RegisterType,
+    pub isunnamed: bool,
+    pub points_to: bool,
+    // #[builder(argtype = "bool", inline = "Some({0})")]
+    // pub conceal: Option<bool>,
+}
+
+impl ToObject for RegisterInfos {
+    fn to_object(self) -> Result<Object, conversion::Error> {
+        self.serialize(Serializer::new()).map_err(Into::into)
+    }
+}
+
+impl FromObject for RegisterInfos {
+    fn from_object(obj: Object) -> Result<Self, conversion::Error> {
+        Self::deserialize(Deserializer::new(obj)).map_err(Into::into)
+    }
+}
+
+fn serialize_as_vec_vec_bytes<S>(
+    v: &[NvimString],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: ser::Serializer,
+{
+    serializer.collect_seq(v.iter().map(|s| s.as_bytes()))
+}

--- a/crates/api/src/types/register_type.rs
+++ b/crates/api/src/types/register_type.rs
@@ -1,44 +1,102 @@
-use serde::{Serialize, ser};
-use types::{conversion::FromObject, serde::Serializer};
+use std::{fmt::Display, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+use types::{
+    Object,
+    String as NvimString,
+    conversion::{self, FromObject, ToObject},
+};
 
 #[non_exhaustive]
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize)]
+// #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+#[derive(
+    Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize,
+)]
+#[serde(into = "String", try_from = "String")]
 pub enum RegisterType {
-    #[serde(serialize_with = "serialize_blockwise")]
-    BlockwiseVisual(Option<usize>),
-
-    #[serde(rename = "c")]
-    Charwise,
-
-    #[serde(rename = "l")]
-    Linewise,
-
-    #[serde(rename = "")]
+    #[default]
     Guess,
+    Char,
+    Line,
+    Block(Option<usize>),
 }
 
-fn serialize_blockwise<S>(
-    width: &Option<usize>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: ser::Serializer,
-{
-    serializer.serialize_str(
-        &(match width {
-            Some(n) => format!("b{n}"),
-            None => "b".to_owned(),
-        }),
-    )
+impl Display for RegisterType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegisterType::Guess => Ok(()),
+            RegisterType::Char => write!(f, "c"),
+            RegisterType::Line => write!(f, "l"),
+            RegisterType::Block(None) => write!(f, "b"),
+            RegisterType::Block(Some(width)) => {
+                write!(f, "b{width}")
+            },
+        }
+    }
 }
 
-impl From<RegisterType> for types::String {
-    fn from(reg_type: RegisterType) -> Self {
-        let obj = reg_type
-            .serialize(Serializer::new())
-            .expect("`RegisterType` is serializable");
+impl FromStr for RegisterType {
+    type Err = conversion::Error;
 
-        Self::from_object(obj)
-            .expect("`RegisterType` is serialized into a string")
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "" => Ok(RegisterType::Guess),
+            "v" | "c" => Ok(RegisterType::Char),
+            "V" | "l" => Ok(RegisterType::Line),
+            _ if let Some(width) = s.strip_prefix(['b', '\x16']) => {
+                match width {
+                    width if width.is_empty() => Ok(RegisterType::Block(None)),
+                    width if let Ok(width) = width.parse::<usize>() => {
+                        Ok(RegisterType::Block(Some(width)))
+                    },
+                    _ => Err(conversion::Error::Other(format!(
+                        "invalid block width suffix: \"{width}\""
+                    ))),
+                }
+            },
+            _ => Err(conversion::Error::Other(format!(
+                "invalid register type string: \"{s}\""
+            ))),
+        }
+    }
+}
+
+impl TryFrom<&str> for RegisterType {
+    type Error = conversion::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl TryFrom<String> for RegisterType {
+    type Error = conversion::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<RegisterType> for String {
+    fn from(value: RegisterType) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<RegisterType> for NvimString {
+    fn from(value: RegisterType) -> Self {
+        Self::from(value.to_string())
+    }
+}
+
+impl FromObject for RegisterType {
+    fn from_object(obj: Object) -> Result<Self, conversion::Error> {
+        String::from_object(obj)?.parse()
+    }
+}
+
+impl ToObject for RegisterType {
+    fn to_object(self) -> Result<Object, conversion::Error> {
+        self.to_string().to_object()
     }
 }

--- a/crates/vimfn/Cargo.toml
+++ b/crates/vimfn/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "nvim-oxi-vimfn"
+description = "Rust bindings to Neovim's Vimscript functions for nvim-oxi"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+documentation.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+
+[package.metadata.docs.rs]
+default-features = false
+features = ["__docsrs", "neovim-nightly", "mlua"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["__no_docsrs"]
+neovim-0-11 = []
+neovim-0-12 = ["neovim-0-11"]
+neovim-nightly = ["neovim-0-12"]
+mlua = ["dep:mlua"]
+
+__docsrs = ["mlua?/vendored"]
+__no_docsrs = ["mlua?/module"]
+
+[dependencies]
+api = { workspace = true }
+luajit = { workspace = true }
+macros = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_repr = { workspace = true }
+thiserror = { workspace = true }
+types = { workspace = true, features = ["serde"] }
+
+mlua = { workspace = true, optional = true }
+
+[lints]
+workspace = true

--- a/crates/vimfn/src/error.rs
+++ b/crates/vimfn/src/error.rs
@@ -1,0 +1,3 @@
+pub(crate) use api::Error;
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/crates/vimfn/src/lib.rs
+++ b/crates/vimfn/src/lib.rs
@@ -6,7 +6,9 @@
 
 mod error;
 pub mod opts;
+mod system;
 pub mod types;
 
 use error::Error;
 use error::Result;
+pub use system::*;

--- a/crates/vimfn/src/lib.rs
+++ b/crates/vimfn/src/lib.rs
@@ -1,0 +1,12 @@
+//! This module contains bindings to
+//! [Neovim's Vimscript functions](https://neovim.io/doc/user/vimfn/#stdpath),
+//! exposed in Lua through the `vim.fn` table.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod error;
+pub mod opts;
+pub mod types;
+
+use error::Error;
+use error::Result;

--- a/crates/vimfn/src/lib.rs
+++ b/crates/vimfn/src/lib.rs
@@ -6,9 +6,11 @@
 
 mod error;
 pub mod opts;
+mod registers;
 mod system;
 pub mod types;
 
 use error::Error;
 use error::Result;
+pub use registers::*;
 pub use system::*;

--- a/crates/vimfn/src/opts/mod.rs
+++ b/crates/vimfn/src/opts/mod.rs
@@ -1,0 +1,3 @@
+mod stdpath;
+
+pub use stdpath::*;

--- a/crates/vimfn/src/opts/stdpath.rs
+++ b/crates/vimfn/src/opts/stdpath.rs
@@ -1,0 +1,26 @@
+use serde::Serialize;
+use types::conversion::FromObject;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StdPath {
+    Cache,
+    Config,
+    ConfigDirs,
+    Data,
+    DataDirs,
+    Log,
+    Run,
+    State,
+}
+
+impl From<StdPath> for types::String {
+    #[inline]
+    fn from(ctx: StdPath) -> Self {
+        types::String::from_object(
+            ctx.serialize(types::serde::Serializer::new())
+                .expect("`StdPath` is serializable"),
+        )
+        .expect("`StdPath` is serialized into a string")
+    }
+}

--- a/crates/vimfn/src/registers.rs
+++ b/crates/vimfn/src/registers.rs
@@ -1,0 +1,64 @@
+use api::SuperIterator;
+use api::types::{RegisterInfos, RegisterType};
+use types::conversion::{FromObject, ToObject};
+use types::{Array, Object, ObjectKind, String as NvimString};
+
+use crate::Error;
+use crate::Result;
+
+/// Binding to [`getreg()`][1].
+///
+/// TODO: copy and adjust documentation
+///
+/// [1]: https://neovim.io/doc/user/vimfn/#getreg()
+pub fn getreg(
+    reg_name: Option<String>,
+    as_raw_expr: bool,
+    split_lines: bool,
+) -> Result<impl SuperIterator<NvimString> + use<>> {
+    let vim_func_name = "getreg";
+    let args = (reg_name.to_object()?, as_raw_expr, split_lines);
+    let ret = api::call_function::<_, Object>(vim_func_name, args)?;
+    let arr = match ret.kind() {
+        ObjectKind::String => Array::from_iter([ret]),
+        ObjectKind::Array => unsafe { ret.into_array_unchecked() },
+        _ => unreachable!("`getreg` should return string or list of strings"),
+    };
+    Ok(arr.into_iter().map(|obj| {
+        NvimString::from_object(obj)
+            .expect("All items returned by `getreg` should be strings.")
+    }))
+}
+
+/// Binding to [`getreginfo()`][1].
+///
+/// TODO: copy and adjust documentation
+///
+/// [1]: https://neovim.io/doc/user/vimfn/#getreginfo()
+pub fn getreginfo(reg_name: Option<String>) -> Result<RegisterInfos> {
+    let vim_func_name = "getreginfo";
+    let args = (reg_name.to_object()?,);
+    let ret = api::call_function::<_, Object>(vim_func_name, args)?;
+    Ok(RegisterInfos::from_object(ret)?)
+}
+
+/// Binding to [`getregtype()`][1].
+///
+/// TODO: copy and adjust documentation
+///
+/// [1]: https://neovim.io/doc/user/vimfn/#getregtype()
+pub fn getregtype(reg_name: Option<String>) -> Result<RegisterType> {
+    let vim_func_name = "getregtype";
+    let args = (reg_name.to_object()?,);
+    let ret = api::call_function::<_, Object>(vim_func_name, args)?;
+    Ok(RegisterType::from_object(ret)?)
+}
+
+/// Binding to [`setreg()`][1].
+///
+/// TODO: copy and adjust documentation
+///
+/// [1]: https://neovim.io/doc/user/vimfn/#setreg()
+pub fn setreg() -> Result<()> {
+    todo!()
+}

--- a/crates/vimfn/src/system.rs
+++ b/crates/vimfn/src/system.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use api::SuperIterator;
+use types::conversion::FromObject;
+use types::{Array, Object, ObjectKind, String as NvimString};
+
+use crate::Result;
+use crate::opts::*;
+
+/// Binding to [`stdpath()`][1].
+///
+/// Returns locations of various default files and directories.
+///
+/// [1]: https://neovim.io/doc/user/vimfn/#stdpath()
+pub fn stdpath(what: StdPath) -> Result<impl SuperIterator<PathBuf> + use<>> {
+    let vim_func_name = "stdpath";
+    let args = (NvimString::from(what),);
+    let ret = api::call_function::<_, Object>(vim_func_name, args)?;
+    let arr = match ret.kind() {
+        ObjectKind::String => Array::from_iter([ret]),
+        ObjectKind::Array => unsafe { ret.into_array_unchecked() },
+        _ => unreachable!("`stdpath` should return string or list of strings"),
+    };
+    Ok(arr.into_iter().map(|obj| {
+        PathBuf::from(
+            types::String::from_object(obj)
+                .expect("All items returned by `stdpath` should be strings."),
+        )
+    }))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,14 @@ pub mod api {
     pub use api::*;
 }
 
+pub mod vimfn {
+    //! Bindings to the [Neovim Vimscript functions][fn].
+    //!
+    //! [fn]: https://neovim.io/doc/user/vimfn/#vimscript-functions
+    #[doc(inline)]
+    pub use vimfn::*;
+}
+
 #[cfg(feature = "libuv")]
 #[cfg_attr(docsrs, doc(cfg(feature = "libuv")))]
 pub mod libuv {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,5 +1,6 @@
 mod api;
 mod r#macro;
+mod vimfn;
 
 // Libuv bindings don't work on Windows.
 #[cfg(not(any(target_os = "windows", target_env = "msvc")))]

--- a/tests/src/vimfn/mod.rs
+++ b/tests/src/vimfn/mod.rs
@@ -1,0 +1,1 @@
+mod system;

--- a/tests/src/vimfn/system.rs
+++ b/tests/src/vimfn/system.rs
@@ -1,0 +1,11 @@
+use nvim_oxi::vimfn::{self, opts::*};
+
+#[nvim_oxi::test]
+fn stdpath() {
+    let _ = vimfn::stdpath(StdPath::Config)
+        .expect("calling `stdpath` for `StdPath::Config` failed")
+        .next()
+        .expect(
+            "calling `stdpath` for `StdPath::Config` didn't return any paths",
+        );
+}


### PR DESCRIPTION
This is a very slow WIP to add bindings to the NVIM Vim script functions (`vim.fn.*`) under `nvim_oxi::vimfn` (because `fn` is a reserved Rust keyword and it would be ugly and inconvenient to use `r#fn` all the time).

For the moment I only add Vim script functions that I need or that others request, so if you need some Vim Script function/s for your plugin/config please open an issue requesting them.

## Currently done and planned Vim Script functions

- [ ] {WIP} `getreg`, `setreg`, `getreginfo`, `getregtype` (#291)
- [x] `stdpath` (#313)